### PR TITLE
Chart options, bug fixes

### DIFF
--- a/api/controllers/PageController.php
+++ b/api/controllers/PageController.php
@@ -234,6 +234,28 @@ class PageController
     }
 
     /**
+     * Edits a template in the DB (only possible for Custom/Shared)
+     * @throws Exception
+     */
+    public function editTemplate()
+    {
+        API::requireValues("courseId", "templateId", "name");
+        
+        $courseId = API::getValue("courseId", "int");
+        $course = API::verifyCourseExists($courseId);
+        
+        API::requireCourseAdminPermission($course);
+
+        $templateId = API::getValue("templateId", "int");
+        $template = API::verifyCustomTemplateExists($templateId);
+
+        $name = API::getValue("name");
+
+        $templateInfo = $template->editTemplate($name)->getDataWithShared();
+        API::response($templateInfo);
+    }
+
+    /**
      * Updates page in the DB
      * @return void
      * @throws Exception
@@ -259,7 +281,6 @@ class PageController
         $isPublic = API::getValue("isPublic", "bool");
 
         $pageInfo = $page->editPage($name, $isVisible, $isPublic, $visibleFrom, $visibleUntil, $position)->getData();
-
         API::response($pageInfo);
     }
 

--- a/api/controllers/PageController.php
+++ b/api/controllers/PageController.php
@@ -810,18 +810,21 @@ class PageController
      */
     public function previewPage()
     {
-        API::requireValues("pageId", "userRole", "viewerRole");
+        API::requireValues("pageId");
 
         $pageId = API::getValue("pageId", "int");
         $page = API::verifyPageExists($pageId);
         
         $course = $page->getCourse();
-        API::requireCoursePermission($course);
+        $courseId = $course->getId();
 
         $userRole = API::getValue("userRole", "string");
-        $viewerRole = API::getValue("viewerRole", "string");
+        $userRoleId = $userRole ? Role::getRoleId($userRole, $courseId) : null;
 
-        API::response($page->previewPage(null, null, Aspect::getAspectBySpecs($course->getId(), $userRole, $viewerRole)));
+        $viewerRole = API::getValue("viewerRole", "string");
+        $viewerRoleId = $viewerRole ? Role::getRoleId($viewerRole, $courseId) : null;
+
+        API::response($page->previewPage(null, null, Aspect::getAspectBySpecs($courseId, $userRoleId, $viewerRoleId)));
     }
 
 

--- a/api/controllers/PageController.php
+++ b/api/controllers/PageController.php
@@ -350,20 +350,14 @@ class PageController
      * @throws Exception
      */
     public function getCoreComponents(){
-        $coreComponents = [];
+        $fun = function($component) {
+            $pair = (object)[];
+            $pair->category = Category::getCategoryById($component["category"])->getName();
+            $pair->view = ViewHandler::renderView($component["viewRoot"])[0];
+            return $pair;
+        };
 
-        foreach (CoreComponent::getComponents() as $component) {
-            $category = Category::getCategoryById($component["category"])->getName();
-            $view = ViewHandler::renderView($component["viewRoot"])[0];
-            $type = $view['type'];
-
-            if (!isset($coreComponents[$type][$category])) {
-                $coreComponents[$type][$category] = [];
-            }
-
-            $coreComponents[$type][$category][] = $view;
-        }
-        
+        $coreComponents = array_map($fun, CoreComponent::getComponents());
         API::response($coreComponents);
     }
 

--- a/api/controllers/PageController.php
+++ b/api/controllers/PageController.php
@@ -285,6 +285,26 @@ class PageController
     }
 
     /**
+     * Updates page positions in the DB
+     * @return void
+     * @throws Exception
+     */
+    public function updatePagePositions(){
+        API::requireValues("courseId", "positions");
+
+        $courseId = API::getValue("courseId", "int");
+        $course = API::verifyCourseExists($courseId);
+        API::requireCoursePermission($course);
+
+        $positions = API::getValue("positions", "array");
+
+        // set all to null to mantain the constraint
+        Page::clearPositions(array_map(function($el) {return $el["id"];}, $positions));
+        // set to new values
+        Page::setPositions($positions);
+    }
+
+    /**
      * Removes page from DB given its ID and course
      *
      * @return void

--- a/api/models/GameCourse/Views/Page/Page.php
+++ b/api/models/GameCourse/Views/Page/Page.php
@@ -506,6 +506,35 @@ class Page
         return $this;
     }
 
+    
+    /**
+     * Clear positions of all pages received as input
+     *
+     * @throws Exception
+     */
+    public static function clearPositions(array $ids)
+    {
+        $sql = "UPDATE page SET position = null WHERE id IN (" . implode(',', $ids) . ")";
+        Core::database()->executeQuery($sql);
+    }
+
+    /**
+     * Sets positions of all pages received as input
+     *
+     * @throws Exception
+     */
+    public static function setPositions(array $array)
+    {
+        $sql = "UPDATE page SET position = CASE ";
+
+        foreach($array as $pair) {
+            $sql .= "WHEN id = " . $pair["id"] . " THEN " . $pair["position"] . " ";
+        }
+        $sql .= "ELSE position END WHERE id IN (" . implode(',', array_map(function($el) {return $el["id"];}, $array)) . ")";
+
+        Core::database()->executeQuery($sql);
+    }
+
     /**
      * Deletes a page from the database and removes all its views.
      * Option to keep views linked to page (created by reference)

--- a/api/models/GameCourse/Views/Template/CustomTemplate.php
+++ b/api/models/GameCourse/Views/Template/CustomTemplate.php
@@ -66,6 +66,29 @@ class CustomTemplate extends Template
         return is_array($data) ? self::parse($data) : self::parse(null, $data, $field);
     }
 
+    /**
+     * Gets all template data (including the fields of shared templates)
+     *
+     * @return mixed
+     */
+    public function getDataWithShared()
+    {
+        $data = Core::database()->select($this::TABLE_TEMPLATE, ["id" => $this->id], "*");
+        $shared = Core::database()->select($this::TABLE_TEMPLATE_SHARED, ["id" => $this->id], "sharedBy, sharedTimestamp");
+        if ($shared) {
+            $data["isPublic"] = true;
+            $data["sharedBy"] = $shared["sharedBy"];
+            $data["sharedTimestamp"] = $shared["sharedTimestamp"];
+        }
+        else {
+            $data["isPublic"] = false;
+            $data["sharedBy"] = null;
+            $data["sharedTimestamp"] = null;
+        }
+        
+        return is_array($data) ? self::parse($data) : self::parse(null, $data, "*");
+    }
+
     /*** ---------------------------------------------------- ***/
     /*** ---------------------- Setters --------------------- ***/
     /*** ---------------------------------------------------- ***/

--- a/frontend/src/app/_components/cards/aspect-card/aspect-card.component.html
+++ b/frontend/src/app/_components/cards/aspect-card/aspect-card.component.html
@@ -5,7 +5,7 @@
   <!-- Actions -->
   <div class="dropdown dropdown-bottom {{editable ? 'flex' : 'hidden'}}
               absolute right-2 top-2 rounded-full btn-ghost hover:cursor-pointer w-7 h-7 flex justify-center items-center transition">
-    <ng-icon tabindex="0" name="tabler-dots-vertical" color="white" size="1.2rem" />
+    <ng-icon tabindex="0" name="tabler-dots-vertical" size="1.2rem" />
     <ul tabindex="0" class="dropdown-content menu p-2 shadow bg-base-100 rounded-box">
       <li (click)="editAction()"><a><ng-icon name="jam-pencil" size="1.5rem"/>Edit</a></li>
       <li (click)="deleteAction()"><a><ng-icon name="feather-X" size="1.5rem" class="text-error"/>Delete</a></li>

--- a/frontend/src/app/_components/cards/datalabel-card/datalabel-card.component.html
+++ b/frontend/src/app/_components/cards/datalabel-card/datalabel-card.component.html
@@ -1,0 +1,40 @@
+<div class="card bg-base-200 shadow-md flex flex-row items-end gap-2 px-5 {{new || edit ? 'py-2' : 'py-6'}}">
+  <div class="grow">
+    <app-input-select
+      *ngIf="edit || new"
+      [id]="'datalabel-serie'"
+      [(value)]="datalabelToAdd.serie"
+      [options]="getSeries()"
+      [placeholder]="'Select specific serie from chart'"
+      [topLabel]="'Add data labels to series:'"
+      [search]="false"
+      [classList]="'-mt-2'"
+      [required]="true"
+    ></app-input-select>
+    <div *ngIf="!edit && !new">
+      <span class="block font-semibold text-md">Serie:</span>{{serie}}
+    </div>
+  </div>
+  <div class="grow">
+    <app-input-text
+      *ngIf="edit || new"
+      [id]="'datalabel-format'"
+      [(value)]="datalabelToAdd.format"
+      [topLabel]="'Format data labels:'"
+      [placeholder]="'e.g.  \'X :\' + this.point.x + \', Y :\' + this.point.y'"
+      [classList]="'-mt-2'"
+    ></app-input-text>
+    <div *ngIf="!edit && !new">
+      <span class="block font-semibold text-md">Format:</span>{{format}}
+    </div>
+  </div>
+  <button *ngIf="new" class="btn btn-secondary" (click)="addNewAction()">Add</button>
+  <div *ngIf="edit" class="flex flex-col">
+    <button class="btn btn-xs btn-ghost" (click)="cancelAction()">Cancel</button>
+    <button class="btn btn-xs btn-secondary" (click)="saveAction()">Save</button>
+  </div>
+  <div *ngIf="!edit && !new" class="ml-auto flex flex-row gap-2">
+    <button class="btn btn-ghost p-0 m-0"><ng-icon name="jam-pencil" size="1.5rem" (click)="editAction()"/></button>
+    <button class="btn btn-ghost p-0 m-0"><ng-icon name="feather-X" size="1.5rem" color="red" (click)="deleteAction()"/></button>
+  </div>
+</div>

--- a/frontend/src/app/_components/cards/datalabel-card/datalabel-card.component.ts
+++ b/frontend/src/app/_components/cards/datalabel-card/datalabel-card.component.ts
@@ -1,0 +1,76 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Output, EventEmitter } from '@angular/core';
+import * as _ from "lodash";
+import { AlertService, AlertType } from 'src/app/_services/alert.service';
+
+@Component({
+  selector: 'app-datalabel-card',
+  templateUrl: './datalabel-card.component.html'
+})
+export class DatalabelCardComponent implements OnInit {
+
+  @Input() chartSeries: string[];
+  @Input() serie: string = null;
+  @Input() format: string = null;
+  @Input() new: boolean = false;
+  @Output() deleteEvent = new EventEmitter<string>();
+  @Output() createEvent = new EventEmitter<{ serie: string, format: string }>();
+  @Output() updateEvent = new EventEmitter<{ serie: string, format: string }>();
+
+  edit?: boolean = false;
+
+  datalabelToAdd: { serie: string, format: string };
+
+  constructor(
+  ) { }
+
+  ngOnInit(): void {
+    if (this.serie) {
+      this.datalabelToAdd = { serie: this.serie, format: this.format };
+    }
+    else {
+      this.datalabelToAdd = { serie: null, format: "" };
+    }
+  }
+
+  getSeries() {
+    return (this.chartSeries ?? []).map((value) => { return ({ value: value, text: value.capitalize() }) })
+  }
+
+  deleteAction() {
+    this.deleteEvent.emit();
+  }
+  
+  addNewAction() {
+    if (this.datalabelToAdd.serie != null) {
+      this.createEvent.emit({
+        serie: this.datalabelToAdd.serie,
+        format: this.datalabelToAdd.format,
+      });
+      this.datalabelToAdd.serie = null;
+      this.datalabelToAdd.format = "";
+    }
+    else AlertService.showAlert(AlertType.ERROR, "Data Label must be associated with a serie");
+  }
+
+  editAction() {
+    this.edit = true;
+  }
+  
+  saveAction() {
+    if (this.datalabelToAdd.serie != null) {
+      this.edit = false;
+      this.updateEvent.emit({
+        serie: this.datalabelToAdd.serie,
+        format: this.datalabelToAdd.format,
+      });
+    }
+    else AlertService.showAlert(AlertType.ERROR, "Data Label must be associated with a serie");
+  }
+  
+  cancelAction() {
+    this.edit = false;
+    this.ngOnInit();
+  }
+  
+}

--- a/frontend/src/app/_components/inputs/color/input-color/input-color.component.html
+++ b/frontend/src/app/_components/inputs/color/input-color/input-color.component.html
@@ -35,7 +35,7 @@
       placeholder="{{placeholder}}"
       [(ngModel)]="value"
       (ngModelChange)="setColor(value)"
-      (keyup.enter)="multiple ? addInput(value) : null"
+      (keyup.enter)="multiple ? addInput() : null"
       [pattern]="pattern"
       [required]="required"
       [minlength]="minLength"
@@ -45,8 +45,14 @@
       [ngClass]="{'input-error': form && form.submitted && inputColor.invalid}"
     />
 
+    
+    <!-- Insert Button -->
+    <button *ngIf="multiple && value" type="button" class="btn btn-square btn-success !rounded-none btn-{{size}}" tabindex="0" (click)="addInput()">
+      <ng-icon [name]="'tabler-check'" size="1.5rem"></ng-icon>
+    </button>
+
     <div class="dropdown dropdown-end" (clickedOutside)="this.closePicker()">
-      <!-- Button -->
+      <!-- Color Picker Button -->
       <button type="button" class="btn btn-square !rounded-r-md !rounded-l-none {{InputGroupBtnColor[color]}} btn-{{size}}" tabindex="0" (click)="openPicker()">
         <ng-icon [name]="'tabler-color-swatch'" size="1.5rem"></ng-icon>
       </button>

--- a/frontend/src/app/_components/inputs/color/input-color/input-color.component.html
+++ b/frontend/src/app/_components/inputs/color/input-color/input-color.component.html
@@ -6,6 +6,15 @@
     <span class="label-text" [ngClass]="{'opacity-50': disabled}">{{topLabel}} <span *ngIf="required" class="text-secondary">*</span></span>
   </label>
 
+  <!-- Multiple Color Samples -->
+  <div *ngIf="multiple" class="w-full flex flex-wrap gap-2 {{values.length > 0 ? 'mb-2' : ''}}">
+    <div *ngFor="let color of values; index as i" class="flex flex-row gap-1 items-center bg-base-300 text-base-content text-sm py-2 px-4 rounded-lg">
+      <div class="w-4 h-4 !rounded shadow border" [ngStyle]="{backgroundColor: color}"></div>
+      {{color}}
+      <span class="bg-base-300 px-0 hover:cursor-pointer" (click)="removeColor(i)">❌</span>
+    </div>
+  </div>
+
   <!-- Group Input -->
   <label class="input-group {{InputGroupSize[size]}} relative">
 
@@ -25,7 +34,8 @@
       class="input input-bordered {{InputSize[size]}} {{InputColor[color]}} {{value ? 'pl-9' : ''}} {{!leftLabel ? '!rounded-l-md' : ''}} w-full cursor-text"
       placeholder="{{placeholder}}"
       [(ngModel)]="value"
-      (ngModelChange)="pickr.setColor(value); valueChange.emit(value)"
+      (ngModelChange)="setColor(value)"
+      (keyup.enter)="multiple ? addInput(value) : null"
       [pattern]="pattern"
       [required]="required"
       [minlength]="minLength"

--- a/frontend/src/app/_components/inputs/color/input-color/input-color.component.ts
+++ b/frontend/src/app/_components/inputs/color/input-color/input-color.component.ts
@@ -20,13 +20,16 @@ export class InputColorComponent implements OnInit, AfterViewInit {
   @Input() value: string;                                             // Where to store the value
   @Input() placeholder: string = '#ffffff';                           // Message to show by default
 
+  @Input() multiple?: boolean = false;                                // Allow several colors instead of just one
+  @Input() values?: string[] = [];                                    // Keep the several colors
+
   // Extras
   @Input() size?: 'xs' | 'sm' | 'md' | 'lg' = 'md';                   // Size FIXME: not working
   @Input() color?: 'ghost' | 'primary' | 'secondary' | 'accent' |     // Color
     'info' | 'success' | 'warning' | 'error';
   @Input() classList?: string;                                        // Classes to add
   @Input() disabled?: boolean;                                        // Make it disabled
-  @Input() colors?: string[];                                   // Custom swatches of colors
+  @Input() colors?: string[];                                          // Custom swatches of colors
 
   @Input() topLabel?: string;                                         // Top label text
   @Input() leftLabel?: string;                                        // Text on prepended label
@@ -51,6 +54,7 @@ export class InputColorComponent implements OnInit, AfterViewInit {
   @Input() incorrectErrorMessage?: string;                            // Message for incorrect error
 
   @Output() valueChange = new EventEmitter<string>();
+  @Output() valuesChange = new EventEmitter<string[]>();
 
   @ViewChild('inputColor', { static: false }) inputColor: NgModel;
 
@@ -133,6 +137,21 @@ export class InputColorComponent implements OnInit, AfterViewInit {
 
     const picker = document.getElementById('color-picker');
     picker.classList.add('hidden');
+  }
+
+  setColor(value: string) {
+    this.pickr.setColor(value)
+    this.valueChange.emit(value);
+  }
+
+  addInput(value: string) {
+    this.values.push(value);
+    this.valuesChange.emit(this.values);
+    this.value = null;
+  }
+
+  removeColor(index: number) {
+    this.values.splice(index, 1);
   }
 
   get InputSize(): typeof InputSize {

--- a/frontend/src/app/_components/inputs/color/input-color/input-color.component.ts
+++ b/frontend/src/app/_components/inputs/color/input-color/input-color.component.ts
@@ -144,8 +144,8 @@ export class InputColorComponent implements OnInit, AfterViewInit {
     this.valueChange.emit(value);
   }
 
-  addInput(value: string) {
-    this.values.push(value);
+  addInput() {
+    this.values.push(this.value);
     this.valuesChange.emit(this.values);
     this.value = null;
   }

--- a/frontend/src/app/_domain/views/templates/template.ts
+++ b/frontend/src/app/_domain/views/templates/template.ts
@@ -5,13 +5,14 @@ export class Template {
   private _id: number;
   private _name: string;
   private _viewRoot: number;
+  private _isSystem: boolean;
+  private _course?: number;
   private _creationTimestamp?: Moment;
   private _updateTimestamp?: Moment;
   private _isPublic?: boolean;
-  private _isSystem: boolean;
   private _sharedTimestamp?: Moment;
 
-  constructor(id: number, name: string, viewRoot: number, creationTimestamp: Moment, updateTimestamp: Moment, isPublic: boolean = false, sharedTimestamp: Moment = null) {
+  constructor(id: number, name: string, viewRoot: number, creationTimestamp: Moment, updateTimestamp: Moment, course: number = null, isPublic: boolean = false, sharedTimestamp: Moment = null) {
     this.id = id;
     this.name = name;
     this.viewRoot = viewRoot;
@@ -19,6 +20,7 @@ export class Template {
     this.updateTimestamp = updateTimestamp;
     this.isPublic = isPublic;
     this.sharedTimestamp = sharedTimestamp;
+    this.course = course;
 
     if (this.creationTimestamp) {
       this.isSystem = false;
@@ -50,6 +52,15 @@ export class Template {
   set viewRoot(value: number) {
     this._viewRoot = value;
   }
+
+  get course(): number {
+    return this._course;
+  }
+
+  set course(value: number) {
+    this._course = value;
+  }
+
 
   get creationTimestamp(): Moment {
     return this._creationTimestamp;
@@ -98,6 +109,7 @@ export class Template {
       obj.view,
       obj.creationTimestamp ? dateFromDatabase(obj.creationTimestamp) : null,
       obj.updateTimestamp ? dateFromDatabase(obj.updateTimestamp) : null,
+      obj.course ? obj.course : null,
       obj.isPublic ? obj.isPublic : null,
       obj.sharedTimestamp ? dateFromDatabase(obj.sharedTimestamp) : null
     );
@@ -108,6 +120,7 @@ export class Template {
 export interface TemplateDatabase {
   id: number;
   name: string;
+  course?: number;
   view: number;
   creationTimestamp?: string;
   updateTimestamp?: string;

--- a/frontend/src/app/_domain/views/view-types/view-block.ts
+++ b/frontend/src/app/_domain/views/view-types/view-block.ts
@@ -6,7 +6,7 @@ import {Variable} from "../variables/variable";
 import {Event} from "../events/event";
 
 import {buildView} from "../build-view/build-view";
-import { groupedChildren, viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
+import { getFakeId, groupedChildren, selectedAspect, viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
 
 export class ViewBlock extends View {
   private _direction: BlockDirection;
@@ -116,16 +116,12 @@ export class ViewBlock extends View {
     this.children.splice(index, 1);
   }
 
-  replaceWithFakeIds(base?: number) { // TODO: refactor view editor
-    // // Replace IDs in children
-    // for (const child of this.children) {
-    //   child.replaceWithFakeIds(exists(base) ? base : null);
-    // }
-    //
-    // const baseId = exists(base) ? base : baseFakeId;
-    // this.id = View.calculateFakeId(baseId, this.id);
-    // this.viewId = View.calculateFakeId(baseId, this.viewId);
-    // this.parentId = View.calculateFakeId(baseId, this.parentId);
+  replaceWithFakeIds() {
+    this.id = getFakeId();
+    // Replace IDs in children
+    for (const child of this.children) {
+      child.replaceWithFakeIds();
+    }
   }
 
   findParent(parentId: number): View { // TODO: refactor view editor
@@ -151,6 +147,18 @@ export class ViewBlock extends View {
     return null;
   }
 
+  replaceView(viewId: number, view: View) {
+    // Look for view in children
+    let index = 0;
+    for (const child of this.children) {
+      if (child.id === viewId) {
+        this.children.splice(index, 1, view);
+      }
+      child.replaceView(viewId, view);
+      index += 1;
+    }
+  }
+
   switchMode(mode: ViewMode) {
     this.mode = mode;
     for (let child of this.children) {
@@ -161,10 +169,8 @@ export class ViewBlock extends View {
   /**
    * Gets a default block view.
    */
-  static getDefault(id: number = null, parentId: number = null, role: string = null, cl: string = null): ViewBlock { // TODO: refactor view editor
-    return null;
-    // return new ViewBlock(id, id, parentId, role, ViewMode.EDIT, [], null, null, null, null,
-    //   View.VIEW_CLASS + ' ' + this.BLOCK_CLASS + (!!cl ? ' ' + cl : ''));
+  static getDefault(parent: View, viewRoot: number, id?: number, aspect?: Aspect): ViewBlock {
+    return new ViewBlock(ViewMode.EDIT, id ?? getFakeId(), viewRoot, parent, aspect ?? selectedAspect, BlockDirection.VERTICAL, null, true, []);
   }
 
   /**

--- a/frontend/src/app/_domain/views/view-types/view-button.ts
+++ b/frontend/src/app/_domain/views/view-types/view-button.ts
@@ -4,7 +4,7 @@ import {Aspect} from "../aspects/aspect";
 import {VisibilityType} from "../visibility/visibility-type";
 import {Variable} from "../variables/variable";
 import {Event} from "../events/event";
-import { viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
+import { getFakeId, selectedAspect, viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
 
 export class ViewButton extends View {
   private _text: string;
@@ -84,11 +84,8 @@ export class ViewButton extends View {
     // Doesn't have children, do nothing
   }
 
-  replaceWithFakeIds(base?: number) { // TODO: refactor view editor
-    // const baseId = exists(base) ? base : baseFakeId;
-    // this.id = View.calculateFakeId(baseId, this.id);
-    // this.viewId = View.calculateFakeId(baseId, this.viewId);
-    // this.parentId = View.calculateFakeId(baseId, this.parentId);
+  replaceWithFakeIds() {
+    this.id = getFakeId();
   }
 
   findParent(parentId: number): View { // TODO: refactor view editor
@@ -101,6 +98,9 @@ export class ViewButton extends View {
     else return null;
   }
 
+  replaceView(viewId: number, view: View) {
+  }
+
   switchMode(mode: ViewMode) {
     this.mode = mode;
   }
@@ -108,10 +108,9 @@ export class ViewButton extends View {
   /**
    * Gets a default button view.
    */
-  static getDefault(id: number = null, parentId: number = null, role: string = null, cl: string = null): ViewButton { // TODO: refactor view editor
-    return null;
-    // return new ViewText(id, id, parentId, role, ViewMode.EDIT, "", null, null, null, null,
-    //   View.VIEW_CLASS + ' ' + this.TEXT_CLASS + (!!cl ? ' ' + cl : ''));
+  static getDefault(parent: View, viewRoot: number, id?: number, aspect?: Aspect): ViewButton {
+    return new ViewButton(ViewMode.EDIT, id ?? getFakeId(), viewRoot, parent, aspect ?? selectedAspect,
+      "", null, null, null, null, null, null, null, null, [], []);
   }
 
 

--- a/frontend/src/app/_domain/views/view-types/view-chart.ts
+++ b/frontend/src/app/_domain/views/view-types/view-chart.ts
@@ -4,7 +4,7 @@ import {Aspect} from "../aspects/aspect";
 import {VisibilityType} from "../visibility/visibility-type";
 import {Variable} from "../variables/variable";
 import {Event} from "../events/event";
-import { viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
+import { getFakeId, selectedAspect, viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
 
 export class ViewChart extends View {
   private _chartType: ChartType;
@@ -84,11 +84,8 @@ export class ViewChart extends View {
     // Doesn't have children, do nothing
   }
 
-  replaceWithFakeIds(base?: number) { // TODO: refactor view editor
-    // const baseId = exists(base) ? base : baseFakeId;
-    // this.id = View.calculateFakeId(baseId, this.id);
-    // this.viewId = View.calculateFakeId(baseId, this.viewId);
-    // this.parentId = View.calculateFakeId(baseId, this.parentId);
+  replaceWithFakeIds() {
+    this.id = getFakeId();
   }
 
   findParent(parentId: number): View { // TODO: refactor view editor
@@ -101,6 +98,9 @@ export class ViewChart extends View {
     else return null;
   }
 
+  replaceView(viewId: number, view: View) {
+  }
+
   switchMode(mode: ViewMode) {
     this.mode = mode;
   }
@@ -108,10 +108,8 @@ export class ViewChart extends View {
   /**
    * Gets a default chart view.
    */
-  static getDefault(id: number = null, parentId: number = null, role: string = null, cl: string = null): ViewChart { // TODO: refactor view editor
-    return null;
-    // return new ViewChart(id, id, parentId, role, ViewMode.EDIT, ChartType.LINE, {provider: ''},
-    //   null, null, null, null, View.VIEW_CLASS + ' ' + this.CHART_CLASS + (!!cl ? ' ' + cl : ''));
+  static getDefault(parent: View, viewRoot: number, id?: number, aspect?: Aspect): ViewChart {
+    return new ViewChart(ViewMode.EDIT, id ?? getFakeId(), viewRoot, parent, aspect ?? selectedAspect, ChartType.LINE, null, {});
   }
 
   /**

--- a/frontend/src/app/_domain/views/view-types/view-collapse.ts
+++ b/frontend/src/app/_domain/views/view-types/view-collapse.ts
@@ -8,7 +8,9 @@ import {Event} from "../events/event";
 import {buildView} from "../build-view/build-view";
 
 import {ErrorService} from "../../../_services/error.service";
-import { groupedChildren, viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
+import { getFakeId, groupedChildren, selectedAspect, viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
+import { ViewText } from "./view-text";
+import { ViewBlock } from "./view-block";
 
 export class ViewCollapse extends View {
   private _icon: CollapseIcon;
@@ -121,16 +123,10 @@ export class ViewCollapse extends View {
     // this.children.splice(index, 1);
   }
 
-  replaceWithFakeIds(base?: number) { // TODO: refactor view editor
-    // // Replace IDs in children
-    // for (const child of this.children) {
-    //   child.replaceWithFakeIds(exists(base) ? base : null);
-    // }
-    //
-    // const baseId = exists(base) ? base : baseFakeId;
-    // this.id = View.calculateFakeId(baseId, this.id);
-    // this.viewId = View.calculateFakeId(baseId, this.viewId);
-    // this.parentId = View.calculateFakeId(baseId, this.parentId);
+  replaceWithFakeIds() {
+    this.id = getFakeId();
+    this.content.replaceWithFakeIds();
+    this.header.replaceWithFakeIds();
   }
 
   findParent(parentId: number): View { // TODO: refactor view editor
@@ -155,6 +151,9 @@ export class ViewCollapse extends View {
     return null;
   }
 
+  replaceView(viewId: number, view: View) {
+  }
+
   switchMode(mode: ViewMode) {
     this.mode = mode;
     this.header.switchMode(mode);
@@ -164,10 +163,9 @@ export class ViewCollapse extends View {
   /**
    * Gets a default collapse view.
    */
-  static getDefault(id: number = null, parentId: number = null, role: string = null, cl: string = null): ViewCollapse { // TODO: refactor view editor
-    return null;
-    // return new ViewBlock(id, id, parentId, role, ViewMode.EDIT, [], null, null, null, null,
-    //   View.VIEW_CLASS + ' ' + this.BLOCK_CLASS + (!!cl ? ' ' + cl : ''));
+  static getDefault(parent: View, viewRoot: number, id?: number, aspect?: Aspect): ViewCollapse {
+    return new ViewCollapse(ViewMode.EDIT, id ?? getFakeId(), viewRoot, parent, aspect ?? selectedAspect, CollapseIcon.ARROW,
+      [ViewText.getDefault(parent, viewRoot, getFakeId(), aspect ?? selectedAspect), ViewBlock.getDefault(parent, viewRoot, getFakeId(), aspect ?? selectedAspect)]);
   }
 
   /**

--- a/frontend/src/app/_domain/views/view-types/view-icon.ts
+++ b/frontend/src/app/_domain/views/view-types/view-icon.ts
@@ -4,7 +4,7 @@ import {Aspect} from "../aspects/aspect";
 import {VisibilityType} from "../visibility/visibility-type";
 import {Variable} from "../variables/variable";
 import {Event} from "../events/event";
-import { viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
+import { getFakeId, selectedAspect, viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
 
 export class ViewIcon extends View {
   private _icon: string;
@@ -74,11 +74,8 @@ export class ViewIcon extends View {
     // Doesn't have children, do nothing
   }
 
-  replaceWithFakeIds(base?: number) { // TODO: refactor view editor
-    // const baseId = exists(base) ? base : baseFakeId;
-    // this.id = View.calculateFakeId(baseId, this.id);
-    // this.viewId = View.calculateFakeId(baseId, this.viewId);
-    // this.parentId = View.calculateFakeId(baseId, this.parentId);
+  replaceWithFakeIds() {
+    this.id = getFakeId();
   }
 
   findParent(parentId: number): View { // TODO: refactor view editor
@@ -91,6 +88,9 @@ export class ViewIcon extends View {
     else return null;
   }
 
+  replaceView(viewId: number, view: View) {
+  }
+
   switchMode(mode: ViewMode) {
     this.mode = mode;
   }
@@ -98,10 +98,8 @@ export class ViewIcon extends View {
   /**
    * Gets a default icon view.
    */
-  static getDefault(id: number = null, parentId: number = null, role: string = null, cl: string = null): ViewIcon { // TODO: refactor view editor
-    return null;
-    // return new ViewText(id, id, parentId, role, ViewMode.EDIT, "", null, null, null, null,
-    //   View.VIEW_CLASS + ' ' + this.TEXT_CLASS + (!!cl ? ' ' + cl : ''));
+  static getDefault(parent: View, viewRoot: number, id?: number, aspect?: Aspect): ViewIcon {
+    return new ViewIcon(ViewMode.EDIT, id ?? getFakeId(), viewRoot, parent, aspect ?? selectedAspect, "tabler-question-mark");
   }
 
 

--- a/frontend/src/app/_domain/views/view-types/view-image.ts
+++ b/frontend/src/app/_domain/views/view-types/view-image.ts
@@ -4,7 +4,7 @@ import {Aspect} from "../aspects/aspect";
 import {VisibilityType} from "../visibility/visibility-type";
 import {Variable} from "../variables/variable";
 import {Event} from "../events/event";
-import { viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
+import { getFakeId, selectedAspect, viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
 
 export class ViewImage extends View {
   private _src: string;
@@ -73,11 +73,8 @@ export class ViewImage extends View {
     // Doesn't have children, do nothing
   }
 
-  replaceWithFakeIds(base?: number) { // TODO: refactor view editor
-    // const baseId = exists(base) ? base : baseFakeId;
-    // this.id = View.calculateFakeId(baseId, this.id);
-    // this.viewId = View.calculateFakeId(baseId, this.viewId);
-    // this.parentId = View.calculateFakeId(baseId, this.parentId);
+  replaceWithFakeIds() {
+    this.id = getFakeId();
   }
 
   findParent(parentId: number): View { // TODO: refactor view editor
@@ -89,6 +86,9 @@ export class ViewImage extends View {
     if (this.id === viewId) return this;
     else return null;
   }
+
+  replaceView(viewId: number, view: View) {
+  }
   
   switchMode(mode: ViewMode) {
     this.mode = mode;
@@ -98,10 +98,8 @@ export class ViewImage extends View {
   /**
    * Gets a default image view.
    */
-  static getDefault(id: number = null, parentId: number = null, role: string = null, cl: string = null): ViewImage { // TODO: refactor view editor
-    return null;
-    // return new ViewImage(id, id, parentId, role, ViewMode.EDIT, "", null, null, null, null,
-    //   View.VIEW_CLASS + ' ' + this.IMAGE_CLASS + (!!cl ? ' ' + cl : ''));
+  static getDefault(parent: View, viewRoot: number, id?: number, aspect?: Aspect): ViewImage {
+    return new ViewImage(ViewMode.EDIT, id ?? getFakeId(), viewRoot, parent, aspect ?? selectedAspect, "assets/imgs/img-dark.png");
   }
 
   /**

--- a/frontend/src/app/_domain/views/view-types/view-row.ts
+++ b/frontend/src/app/_domain/views/view-types/view-row.ts
@@ -5,7 +5,7 @@ import {VisibilityType} from "../visibility/visibility-type";
 import {Variable} from "../variables/variable";
 import {Event} from "../events/event";
 import { buildView } from "../build-view/build-view";
-import { groupedChildren, viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
+import { getFakeId, groupedChildren, viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
 
 
 export class ViewRow extends View {
@@ -99,16 +99,12 @@ export class ViewRow extends View {
     // this.children.splice(index, 1);
   }
 
-  replaceWithFakeIds(base?: number) { // TODO: refactor view editor
-    // // Replace IDs in children
-    // for (const child of this.children) {
-    //   child.replaceWithFakeIds(exists(base) ? base : null);
-    // }
-    //
-    // const baseId = exists(base) ? base : baseFakeId;
-    // this.id = View.calculateFakeId(baseId, this.id);
-    // this.viewId = View.calculateFakeId(baseId, this.viewId);
-    // this.parentId = View.calculateFakeId(baseId, this.parentId);
+  replaceWithFakeIds() {
+    this.id = getFakeId();
+    // Replace IDs in children
+    for (const child of this.children) {
+      child.replaceWithFakeIds();
+    }
   }
 
   findParent(parentId: number): View { // TODO: refactor view editor
@@ -134,6 +130,9 @@ export class ViewRow extends View {
     return null;
   }
 
+  replaceView(viewId: number, view: View) {
+  }
+
   switchMode(mode: ViewMode) {
     this.mode = mode;
     for (let child of this.children) child.switchMode(mode);
@@ -143,8 +142,8 @@ export class ViewRow extends View {
   /**
    * Gets a default row view.
    */
-  static getDefault(id: number, table: View, parentId: number = null, aspect: Aspect, type: RowType): ViewRow { // TODO: refactor view editor
-    return new ViewRow(ViewMode.EDIT, id, parentId, table, aspect, type, [],
+  static getDefault(id: number, table: View, viewRoot: number = null, aspect: Aspect, type: RowType): ViewRow {
+    return new ViewRow(ViewMode.EDIT, id, viewRoot, table, aspect, type, [],
       null, null, null, VisibilityType.VISIBLE, null, null, [], []);
   }
 

--- a/frontend/src/app/_domain/views/view-types/view-table.ts
+++ b/frontend/src/app/_domain/views/view-types/view-table.ts
@@ -9,7 +9,7 @@ import {Event} from "../events/event";
 import {buildView} from "../build-view/build-view";
 
 import {ErrorService} from "../../../_services/error.service";
-import { groupedChildren, viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
+import { getFakeId, groupedChildren, selectedAspect, viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
 
 export class ViewTable extends View {
   private _headerRows: ViewRow[];
@@ -227,19 +227,15 @@ export class ViewTable extends View {
     // Table has its own editor, do nothing
   }
 
-  replaceWithFakeIds(base?: number) { // TODO: refactor view editor
-    // // Replace IDs in children
-    // for (const headerRow of this.headerRows) {
-    //   headerRow.replaceWithFakeIds(exists(base) ? base : null);
-    // }
-    // for (const row of this.rows) {
-    //   row.replaceWithFakeIds(exists(base) ? base : null);
-    // }
-    //
-    // const baseId = exists(base) ? base : baseFakeId;
-    // this.id = View.calculateFakeId(baseId, this.id);
-    // this.viewId = View.calculateFakeId(baseId, this.viewId);
-    // this.parentId = View.calculateFakeId(baseId, this.parentId);
+  replaceWithFakeIds() {
+    this.id = getFakeId();
+    // Replace IDs in children
+    for (const headerRow of this.headerRows) {
+      headerRow.replaceWithFakeIds();
+    }
+    for (const row of this.bodyRows) {
+      row.replaceWithFakeIds();
+    }
   }
 
   findParent(parentId: number): View { // TODO: refactor view editor
@@ -271,6 +267,9 @@ export class ViewTable extends View {
       if (found) return row;
     }
     return null;
+  }
+
+  replaceView(viewId: number, view: View) {
   }
 
   switchMode(mode: ViewMode) {
@@ -365,13 +364,11 @@ export class ViewTable extends View {
   /**
    * Gets a default table view.
    */
-  static getDefault(id: number = null, parentId: number = null, role: string = null, cl: string = null): ViewTable { // TODO: refactor view editor
-    return null;
-    // return new ViewTable(id, id, parentId, role, ViewMode.EDIT,
-    //   [ViewRow.getDefault(id - 1, id, role, this.TABLE_HEADER_CLASS)],
-    //   [ViewRow.getDefault(id - 3, id, role, this.TABLE_BODY_CLASS)],
-    //   null, null, null, null,
-    //   View.VIEW_CLASS + ' ' + this.TABLE_CLASS + (!!cl ? ' ' + cl : ''));
+  static getDefault(parent: View, viewRoot: number, id?: number, aspect?: Aspect): ViewTable { // TODO: refactor view editor
+    const table = new ViewTable(ViewMode.EDIT, id ?? getFakeId(), viewRoot, parent, aspect ?? selectedAspect, false, false, false, false, false, false, false, null, []);
+    table.headerRows = [ViewRow.getDefault(getFakeId(), table, viewRoot, aspect ?? selectedAspect, RowType.HEADER)];
+    table.bodyRows = [ViewRow.getDefault(getFakeId(), table, viewRoot, aspect ?? selectedAspect, RowType.BODY)];
+    return table;
   }
 
   /**

--- a/frontend/src/app/_domain/views/view-types/view-text.ts
+++ b/frontend/src/app/_domain/views/view-types/view-text.ts
@@ -4,7 +4,7 @@ import {Aspect} from "../aspects/aspect";
 import {VisibilityType} from "../visibility/visibility-type";
 import {Variable} from "../variables/variable";
 import {Event} from "../events/event";
-import { viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
+import { getFakeId, selectedAspect, viewTree, viewsAdded } from "../build-view-tree/build-view-tree";
 
 export class ViewText extends View {
   private _text: string;
@@ -74,11 +74,8 @@ export class ViewText extends View {
     // Doesn't have children, do nothing
   }
 
-  replaceWithFakeIds(base?: number) { // TODO: refactor view editor
-    // const baseId = exists(base) ? base : baseFakeId;
-    // this.id = View.calculateFakeId(baseId, this.id);
-    // this.viewId = View.calculateFakeId(baseId, this.viewId);
-    // this.parentId = View.calculateFakeId(baseId, this.parentId);
+  replaceWithFakeIds() {
+    this.id = getFakeId();
   }
 
   findParent(parentId: number): View { // TODO: refactor view editor
@@ -91,6 +88,9 @@ export class ViewText extends View {
     else return null;
   }
 
+  replaceView(viewId: number, view: View) {
+  }
+
   switchMode(mode: ViewMode) {
     this.mode = mode;
   }
@@ -98,8 +98,9 @@ export class ViewText extends View {
   /**
    * Gets a default text view.
    */
-  static getDefault(id: number, parentId: number = null, parent: View, aspect: Aspect, text: string = ""): ViewText { // TODO: refactor view editor
-    return new ViewText(ViewMode.EDIT, id, parentId, parent, aspect, text, null, null, null, null, VisibilityType.VISIBLE, null, null, [], []);
+  static getDefault(parent: View, viewRoot: number, id?: number, aspect?: Aspect, text?: string): ViewText { // TODO: refactor view editor
+    return new ViewText(ViewMode.EDIT, id, viewRoot, parent, aspect ?? selectedAspect, text ?? "",
+      null, null, null, null, VisibilityType.VISIBLE, null, null, [], []);
   }
 
 

--- a/frontend/src/app/_domain/views/view.ts
+++ b/frontend/src/app/_domain/views/view.ts
@@ -193,6 +193,8 @@ export abstract class View {
 
   abstract findView(viewId: number): View;
 
+  abstract replaceView(viewId: number, view: View);
+
   abstract switchMode(mode: ViewMode);
 
 

--- a/frontend/src/app/_services/api/api-http.service.ts
+++ b/frontend/src/app/_services/api/api-http.service.ts
@@ -72,7 +72,7 @@ import {
 } from 'src/app/_views/restricted/courses/course/settings/adaptation/adaptation.component';
 import { Streak } from 'src/app/_views/restricted/courses/course/pages/course-page/course-page.component';
 import {CustomFunction} from "../../_components/inputs/code/input-code/input-code.component";
-import {PageManageData} from "../../_views/restricted/courses/course/settings/views/views/views.component";
+import {PageManageData, TemplateManageData} from "../../_views/restricted/courses/course/settings/views/views/views.component";
 import { Aspect } from 'src/app/_domain/views/aspects/aspect';
 import { ViewType } from 'src/app/_domain/views/view-types/view-type';
 
@@ -3058,6 +3058,23 @@ export class ApiHttpService {
     const url = this.apiEndpoint.createUrlWithQueryParameters('', params);
     return this.post(url, data, ApiHttpService.httpOptions)
       .pipe( map((res: any) => res) );
+  }
+
+  public editTemplate(courseID: number, template: TemplateManageData): Observable<Template> {
+    const data = {
+      courseId: courseID,
+      templateId: template.id,
+      name: template.name,
+    };
+
+    const params = (qs: QueryStringParameters) => {
+      qs.push('module', ApiHttpService.PAGE);
+      qs.push('request', 'editTemplate');
+    };
+
+    const url = this.apiEndpoint.createUrlWithQueryParameters('', params);
+    return this.post(url, data, ApiHttpService.httpOptions)
+      .pipe( map((res: any) => Template.fromDatabase(res['data'])) );
   }
 
   // Pages //////////////////////////////////////////////////////////////////////////

--- a/frontend/src/app/_services/api/api-http.service.ts
+++ b/frontend/src/app/_services/api/api-http.service.ts
@@ -3274,6 +3274,22 @@ export class ApiHttpService {
       .pipe( map((res: any) => Page.fromDatabase(res['data'])) );
   }
 
+  public updatePagePositions(courseID: number, positions: {page: number, position: number}[]): Observable<void> {
+    const data = {
+      courseId: courseID,
+      positions: positions
+    };
+
+    const params = (qs: QueryStringParameters) => {
+      qs.push('module', ApiHttpService.PAGE);
+      qs.push('request', 'updatePagePositions');
+    };
+
+    const url = this.apiEndpoint.createUrlWithQueryParameters('', params);
+    return this.post(url, data, ApiHttpService.httpOptions)
+      .pipe( map((res: any) => res) );
+  }
+
   public deletePage(courseID: number, pageId: number): Observable<void> {
     const data = {
       courseId: courseID,

--- a/frontend/src/app/_services/api/api-http.service.ts
+++ b/frontend/src/app/_services/api/api-http.service.ts
@@ -3241,8 +3241,12 @@ export class ApiHttpService {
       qs.push('module', ApiHttpService.PAGE);
       qs.push('request', 'previewPage');
       qs.push('pageId', pageID);
-      qs.push('userRole', aspect.userRole);
-      qs.push('viewerRole', aspect.viewerRole);
+      if (aspect.userRole) {
+        qs.push('userRole', aspect.userRole);
+      }
+      if (aspect.viewerRole) {
+        qs.push('viewerRole', aspect.viewerRole);
+      }
     };
 
     const url = this.apiEndpoint.createUrlWithQueryParameters('', params);

--- a/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.html
+++ b/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.html
@@ -644,27 +644,37 @@
     </div>
   </div>
 
-<!--   <div class="flex flex-row mt-2 justify-start items-center gap-2">
+  <div class="flex flex-row mt-4 justify-start items-center gap-2">
     <span class="block font-semibold text-mg pl-1">Data Labels</span>
   </div>
   <div class="text-xs pl-1 pb-2">
     Textual or numeric labels that are associated with individual data points or series on the chart. They provide additional information about the data being displayed, making it easier for viewers to interpret the chart.
   </div>
   <app-input-checkbox
-    [id]="'block-responsive'"
-    [(value)]="viewToEdit.options."
+    [id]="'chart-datalabels'"
+    [(value)]="viewToEdit.options.dataLabels"
     [color]="'primary'"
-    (valueChange)="viewToEdit.responsive = !viewToEdit.responsive"
     [label]="'Add data labels to this chart'"
-    [labelPosition]="'right'">
-  </app-input-checkbox> -->
+    [labelPosition]="'right'"
+  ></app-input-checkbox>
+  <!-- TODO: Options for datalabels. Only certain series, and formatting.
+  <ng-container *ngIf="viewToEdit.options.dataLabels">
+    <div class="flex flex-col gap-2 mb-2 grow-0">
+      <div *ngFor="let el of viewToEdit.options.dataLabelsOnSeries; index as i">
+        <app-datalabel-card [el]="el" [chartSeries]="viewToEdit.options.series" [serie]="el.serie" [format]="el.format" (deleteEvent)="deleteDataLabel(i)" (updateEvent)="updateDataLabel($event, i)"/>
+      </div>
+      <app-datalabel-card [chartSeries]="viewToEdit.options.series" [new]="true" (createEvent)="addDataLabel($event)"/>
+    </div>
+  </ng-container> 
+  -->
 
   <div class="flex flex-row mt-4 justify-start items-center gap-2">
     <span class="block font-semibold text-mg pl-1">Axis</span>
   </div>
   <div class="grid grid-cols-2">
-    <div class="border-r-2 border-neutral/10 px-4">
+    <div class="border-r-2 border-neutral/10 px-4"> <!-------------- X AXIS ------------------->
       <app-input-text
+        *ngIf="viewToEdit.chartType !== 'radar'"
         [id]="'chart-x-label'"
         [(value)]="viewToEdit.options.XAxisLabel"
         [placeholder]="'e.g. \'Time (days)\' '"
@@ -672,6 +682,7 @@
         [topLabel]="'X-Axis label'"
       ></app-input-text>
       <app-input-number
+        *ngIf="viewToEdit.chartType !== 'radar'"
         [id]="'chart-x-ticks'"
         [(value)]="viewToEdit.options.XAxisTickAmount"
         [topLabel]="'X-Axis amount of ticks'"
@@ -693,9 +704,9 @@
           <span class="block font-semibold text-mg pl-1">Add categories</span>
         </div>
         <div class="flex flex-row gap-2 mb-2">
-          <div *ngFor="let cat of this.viewToEdit.options.XAxisCategories; index as i" class="flex flex-row bg-secondary text-white py-1 px-2 rounded-lg text-sm">
+          <div *ngFor="let cat of this.viewToEdit.options.XAxisCategories; index as i" class="flex flex-row border border-base-content text-base-content py-0.5 px-2 rounded-full text-sm">
             {{cat}}
-            <span (click)="removeXAxisCategory(i)" class="hover:cursor-pointer">❌</span>
+            <span (click)="removeXAxisCategory(i)" class="ml-2 hover:cursor-pointer">x</span>
           </div>
         </div>
         <div class="flex flex-row gap-2">
@@ -718,16 +729,20 @@
         [classList]="'mt-4'"
       ></app-input-checkbox>
       <app-input-checkbox
-        *ngIf="viewToEdit.options.XAxisGrid"
-        [id]="'chart-stripped'"
-        [(value)]="viewToEdit.options.stripedGrid"
+        *ngIf="viewToEdit.chartType !== 'radar' && viewToEdit.options.XAxisGrid"
+        [disabled]="strippedGridHorizontal"
+        [id]="'chart-stripped-x'"
+        [(value)]="strippedGridVertical"
         [color]="'primary'"
         [label]="'Show stripped grid (alternate grid-lines)'"
         [labelPosition]="'right'"
         [classList]="'ml-6 -mt-2'"
+        (valueChange)="changeStripedGrid($event, 'vertical')"
       ></app-input-checkbox>
+      <span *ngIf="strippedGridHorizontal" class="text-warning">You can only have one stripped grid in chart</span>
     </div>
-    <div class="px-4">
+
+    <div class="px-4" *ngIf="viewToEdit.chartType !== 'radar'"> <!-------------- Y AXIS ------------------->
       <app-input-text
         [id]="'chart-y-label'"
         [(value)]="viewToEdit.options.YAxisLabel"
@@ -774,12 +789,24 @@
       ></app-input-checkbox>
       <app-input-checkbox
         *ngIf="viewToEdit.options.YAxisGrid"
-        [id]="'chart-stripped'"
-        [(value)]="viewToEdit.options.stripedGrid"
+        [disabled]="strippedGridVertical"
+        [id]="'chart-stripped-y'"
+        [(value)]="strippedGridHorizontal"
         [color]="'primary'"
         [label]="'Show stripped grid (alternate grid-lines)'"
         [labelPosition]="'right'"
         [classList]="'ml-6 -mt-2'"
+        (valueChange)="changeStripedGrid($event, 'horizontal')"
+      ></app-input-checkbox>
+      <span *ngIf="strippedGridVertical" class="text-warning">You can only have one stripped grid in chart</span>
+    </div>
+    <div class="px-4" *ngIf="viewToEdit.chartType === 'radar'"> <!-------------- Y AXIS ------------------->
+      <app-input-checkbox
+        [id]="'chart-normalized'"
+        [(value)]="viewToEdit.options.normalized"
+        [color]="'primary'"
+        [label]="'Normalize data series'"
+        [labelPosition]="'right'"
       ></app-input-checkbox>
     </div>
   </div>
@@ -885,56 +912,110 @@
     </div>
   </div>
 
-  <div class="flex flex-row mt-8 justify-start items-center gap-2">
-    <span class="block font-semibold text-mg pl-1">Data display</span>
-  </div>
-  <div class="grid grid-cols-3 gap-2">
-    <div class="border-r-2 border-neutral/10 p-4">
-      <div class="bg-base-300 rounded-xl p-4">
-        <app-input-select
-          [id]="'chart-lines'"
-          [(value)]="viewToEdit.options.strokeCurve"
-          [options]="getChartStrokeCurveOptions()"
-          [placeholder]="'Select stroke curve'"
-          [topLabel]="'Type of lines'"
-          [required]="false"
-          [search]="false"
-        ></app-input-select>
+  <ng-container *ngIf="viewToEdit.chartType === 'line' || viewToEdit.chartType === 'combo'">
+    <div class="flex flex-row mt-8 justify-start items-center gap-2">
+      <span class="block font-semibold text-mg pl-1">Data display</span>
+    </div>
+    <div class="grid grid-cols-3 gap-2">
+      <div class="border-r-2 border-neutral/10 p-4">
+        <div class="bg-base-300 rounded-xl p-4">
+          <app-input-select
+            [id]="'chart-lines'"
+            [(value)]="viewToEdit.options.strokeCurve"
+            [options]="getChartStrokeCurveOptions()"
+            [placeholder]="'Select stroke curve'"
+            [topLabel]="'Type of lines'"
+            [required]="false"
+            [search]="false"
+          ></app-input-select>
+        </div>
+      </div>
+      <div class="border-r-2 border-neutral/10 p-4">
+        <div class="bg-base-300 rounded-xl p-4">
+          <app-input-select
+            [id]="'chart-ends'"
+            [(value)]="viewToEdit.options.strokeLineCap"
+            [options]="getChartLineCapOptions()"
+            [placeholder]="'Select line cap'"
+            [topLabel]="'Type of start and end of line'"
+            [required]="false"
+            [search]="false"
+          ></app-input-select>
+        </div>
+      </div>
+      <div class="p-4">
+        <app-input-number
+          [id]="'chart-line-width'"
+          [(value)]="viewToEdit.options.strokeWidth"
+          [topLabel]="'Width of lines'"
+          [placeholder]="'Select a maximum number'"
+        ></app-input-number>
+        <app-input-number
+          [id]="'chart-marker-size'"
+          [(value)]="viewToEdit.options.markersSize"
+          [topLabel]="'Data points marker size'"
+          [placeholder]="'Select a maximum number'"
+        ></app-input-number>
       </div>
     </div>
-    <div class="border-r-2 border-neutral/10 p-4">
-      <div class="bg-base-300 rounded-xl p-4">
-        <app-input-select
-          [id]="'chart-ends'"
-          [(value)]="viewToEdit.options.strokeLineCap"
-          [options]="getChartLineCapOptions()"
-          [placeholder]="'Select line cap'"
-          [topLabel]="'Type of start and end of line'"
-          [required]="false"
-          [search]="false"
-        ></app-input-select>
-      </div>
-    </div>
-    <div class="p-4">
-      <app-input-number
-        [id]="'chart-line-width'"
-        [(value)]="viewToEdit.options.strokeWidth"
-        [topLabel]="'Width of lines'"
-        [placeholder]="'Select a maximum number'"
-      ></app-input-number>
-      <app-input-number
-        [id]="'chart-marker-size'"
-        [(value)]="viewToEdit.options.markersSize"
-        [topLabel]="'Data points marker size'"
-        [placeholder]="'Select a maximum number'"
-      ></app-input-number>
-    </div>
-  </div>
+  </ng-container>
 
-  <div class="flex flex-row mt-4 justify-start items-center gap-2">
+  <div class="flex flex-row mt-8 justify-start items-center gap-2">
     <span class="block font-semibold text-mg pl-1">Extras</span>
   </div>
-  <div class="grid grid-cols-2">
+  
+  <!-- BAR CHART EXTRAS -->
+  <div *ngIf="viewToEdit.chartType === 'bar'" class="grid grid-cols-2 gap-8">
+    <div>
+      <div class="flex flex-row mt-2 justify-start items-center gap-2">
+        <span class="block font-semibold text-md">Bars orientation</span>
+      </div>
+      <div class="flex flex-wrap">
+        <app-input-radio
+          [id]="'chart-orientation-vertical'"
+          [group]="'orientation'"
+          [optionValue]="'vertical'"
+          [(value)]="viewToEdit.options.orientation"
+          [color]="'primary'"
+          [classList]="'mr-8'"
+          [label]="'Vertical'">
+        </app-input-radio>
+        <app-input-radio
+          [id]="'chart-orientation-horizontal'"
+          [group]="'orientation'"
+          [optionValue]="'horizontal'"
+          [(value)]="viewToEdit.options.orientation"
+          [color]="'primary'"
+          [classList]="'mr-8'"
+          [label]="'Horizontal'">
+        </app-input-radio>
+      </div>
+    </div>
+    <app-input-number
+      [id]="'chart-bars-radius'"
+      [(value)]="viewToEdit.options.borderRadius"
+      [topLabel]="'Bars radius'"
+      [placeholder]="'Select a number'"
+    ></app-input-number>
+  </div>
+
+  <!-- RADAR CHART EXTRAS -->
+  <div *ngIf="viewToEdit.chartType === 'radar'" class="grid grid-cols-2 gap-8">
+    <app-input-number
+      [id]="'chart-radar-points'"
+      [(value)]="viewToEdit.options.markersSize"
+      [topLabel]="'Data points marker size'"
+      [placeholder]="'Select a number'"
+    ></app-input-number>
+    <app-input-number
+      [id]="'chart-radar-width'"
+      [(value)]="viewToEdit.options.strokeWidth"
+      [topLabel]="'Stroke width'"
+      [placeholder]="'Select a number'"
+    ></app-input-number>
+  </div>
+
+  <!-- <div class="grid grid-cols-2"> -->
     <app-input-checkbox
       [id]="'chart-sparkline'"
       [(value)]="viewToEdit.options.sparkline"
@@ -942,6 +1023,7 @@
       [label]="'Create spark-line of graph (hide everything but primary paths)'"
       [labelPosition]="'right'"
     ></app-input-checkbox>
+    <!-- TODO : extra for line chart - toolbar actions
     <div>
       <app-input-checkbox
         [id]="'chart-toolbar'"
@@ -961,7 +1043,7 @@
           [search]="false"
         ></app-input-select>
       </div>
-    </div>
-  </div>
+    </div> -->
+  <!-- </div> -->
 
 </ng-template>

--- a/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.html
+++ b/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.html
@@ -644,172 +644,176 @@
     </div>
   </div>
 
-  <div class="flex flex-row mt-4 justify-start items-center gap-2">
-    <span class="block font-semibold text-mg pl-1">Data Labels</span>
-  </div>
-  <div class="text-xs pl-1 pb-2">
-    Textual or numeric labels that are associated with individual data points or series on the chart. They provide additional information about the data being displayed, making it easier for viewers to interpret the chart.
-  </div>
-  <app-input-checkbox
-    [id]="'chart-datalabels'"
-    [(value)]="viewToEdit.options.dataLabels"
-    [color]="'primary'"
-    [label]="'Add data labels to this chart'"
-    [labelPosition]="'right'"
-  ></app-input-checkbox>
-  <!-- TODO: Options for datalabels. Only certain series, and formatting.
-  <ng-container *ngIf="viewToEdit.options.dataLabels">
-    <div class="flex flex-col gap-2 mb-2 grow-0">
-      <div *ngFor="let el of viewToEdit.options.dataLabelsOnSeries; index as i">
-        <app-datalabel-card [el]="el" [chartSeries]="viewToEdit.options.series" [serie]="el.serie" [format]="el.format" (deleteEvent)="deleteDataLabel(i)" (updateEvent)="updateDataLabel($event, i)"/>
-      </div>
-      <app-datalabel-card [chartSeries]="viewToEdit.options.series" [new]="true" (createEvent)="addDataLabel($event)"/>
+  <ng-container *ngIf="viewToEdit.chartType !== 'pie'">
+    <div class="flex flex-row mt-4 justify-start items-center gap-2">
+      <span class="block font-semibold text-mg pl-1">Data Labels</span>
     </div>
-  </ng-container> 
-  -->
-
-  <div class="flex flex-row mt-4 justify-start items-center gap-2">
-    <span class="block font-semibold text-mg pl-1">Axis</span>
-  </div>
-  <div class="grid grid-cols-2">
-    <div class="border-r-2 border-neutral/10 px-4"> <!-------------- X AXIS ------------------->
-      <app-input-text
-        *ngIf="viewToEdit.chartType !== 'radar'"
-        [id]="'chart-x-label'"
-        [(value)]="viewToEdit.options.XAxisLabel"
-        [placeholder]="'e.g. \'Time (days)\' '"
-        [required]="false"
-        [topLabel]="'X-Axis label'"
-      ></app-input-text>
-      <app-input-number
-        *ngIf="viewToEdit.chartType !== 'radar'"
-        [id]="'chart-x-ticks'"
-        [(value)]="viewToEdit.options.XAxisTickAmount"
-        [topLabel]="'X-Axis amount of ticks'"
-        [helperText]="'Determine approximately the number of ticks (grid-lines) displayed on the X-axis of the chart. It helps to improve readability.'"
-        [helperPosition]="'right'"
-      ></app-input-number>
-      <app-input-select
-        [id]="'chart-x-type'"
-        [(value)]="viewToEdit.options.XAxisType"
-        [options]="getXAxisDataTypes()"
-        [placeholder]="'Select X-Axis data type'"
-        [topLabel]="'X-Axis type of data'"
-        [required]="false"
-      ></app-input-select>
-
-      <div class="bg-base-300 rounded-xl p-4 mt-4">
-        <div class="flex flex-row justify-start items-center gap-2">
-          <app-simple-helper [position]="'right'" [text]="'Categories for each data series. They will be sorted in the order they were included.'"></app-simple-helper>
-          <span class="block font-semibold text-mg pl-1">Add categories</span>
+    <div class="text-xs pl-1 pb-2">
+      Textual or numeric labels that are associated with individual data points or series on the chart. They provide additional information about the data being displayed, making it easier for viewers to interpret the chart.
+    </div>
+    <app-input-checkbox
+      [id]="'chart-datalabels'"
+      [(value)]="viewToEdit.options.dataLabels"
+      [color]="'primary'"
+      [label]="'Add data labels to this chart'"
+      [labelPosition]="'right'"
+    ></app-input-checkbox>
+    <!-- TODO: Options for datalabels. Only certain series, and formatting.
+    <ng-container *ngIf="viewToEdit.options.dataLabels">
+      <div class="flex flex-col gap-2 mb-2 grow-0">
+        <div *ngFor="let el of viewToEdit.options.dataLabelsOnSeries; index as i">
+          <app-datalabel-card [el]="el" [chartSeries]="viewToEdit.options.series" [serie]="el.serie" [format]="el.format" (deleteEvent)="deleteDataLabel(i)" (updateEvent)="updateDataLabel($event, i)"/>
         </div>
-        <div class="flex flex-row gap-2 mb-2">
-          <div *ngFor="let cat of this.viewToEdit.options.XAxisCategories; index as i" class="flex flex-row border border-base-content text-base-content py-0.5 px-2 rounded-full text-sm">
-            {{cat}}
-            <span (click)="removeXAxisCategory(i)" class="ml-2 hover:cursor-pointer">x</span>
+        <app-datalabel-card [chartSeries]="viewToEdit.options.series" [new]="true" (createEvent)="addDataLabel($event)"/>
+      </div>
+    </ng-container> 
+    -->
+  </ng-container>
+
+  <ng-container *ngIf="viewToEdit.chartType !== 'pie'">
+    <div class="flex flex-row mt-4 justify-start items-center gap-2">
+      <span class="block font-semibold text-mg pl-1">Axis</span>
+    </div>
+    <div class="grid grid-cols-2">
+      <div class="border-r-2 border-neutral/10 px-4"> <!-------------- X AXIS ------------------->
+        <app-input-text
+          *ngIf="viewToEdit.chartType !== 'radar'"
+          [id]="'chart-x-label'"
+          [(value)]="viewToEdit.options.XAxisLabel"
+          [placeholder]="'e.g. \'Time (days)\' '"
+          [required]="false"
+          [topLabel]="'X-Axis label'"
+        ></app-input-text>
+        <app-input-number
+          *ngIf="viewToEdit.chartType !== 'radar'"
+          [id]="'chart-x-ticks'"
+          [(value)]="viewToEdit.options.XAxisTickAmount"
+          [topLabel]="'X-Axis amount of ticks'"
+          [helperText]="'Determine approximately the number of ticks (grid-lines) displayed on the X-axis of the chart. It helps to improve readability.'"
+          [helperPosition]="'right'"
+        ></app-input-number>
+        <app-input-select
+          [id]="'chart-x-type'"
+          [(value)]="viewToEdit.options.XAxisType"
+          [options]="getXAxisDataTypes()"
+          [placeholder]="'Select X-Axis data type'"
+          [topLabel]="'X-Axis type of data'"
+          [required]="false"
+        ></app-input-select>
+
+        <div class="bg-base-300 rounded-xl p-4 mt-4">
+          <div class="flex flex-row justify-start items-center gap-2">
+            <app-simple-helper [position]="'right'" [text]="'Categories for each data series. They will be sorted in the order they were included.'"></app-simple-helper>
+            <span class="block font-semibold text-mg pl-1">Add categories</span>
+          </div>
+          <div class="flex flex-row gap-2 mb-2">
+            <div *ngFor="let cat of this.viewToEdit.options.XAxisCategories; index as i" class="flex flex-row border border-base-content text-base-content py-0.5 px-2 rounded-full text-sm">
+              {{cat}}
+              <span (click)="removeXAxisCategory(i)" class="ml-2 hover:cursor-pointer">x</span>
+            </div>
+          </div>
+          <div class="flex flex-row gap-2">
+            <app-input-text
+              [id]="'chart-x-label'"
+              [(value)]="categoryToAdd"
+              [placeholder]="'Add a category'"
+              [required]="false"
+            ></app-input-text>
+            <button class="btn btn-secondary" (click)="addXAxisCategory()">Add</button>
           </div>
         </div>
-        <div class="flex flex-row gap-2">
-          <app-input-text
-            [id]="'chart-x-label'"
-            [(value)]="categoryToAdd"
-            [placeholder]="'Add a category'"
-            [required]="false"
-          ></app-input-text>
-          <button class="btn btn-secondary" (click)="addXAxisCategory()">Add</button>
-        </div>
+
+        <app-input-checkbox
+          [id]="'chart-x-grid'"
+          [(value)]="viewToEdit.options.XAxisGrid"
+          [color]="'primary'"
+          [label]="'Show grid on X-Axis'"
+          [labelPosition]="'right'"
+          [classList]="'mt-4'"
+        ></app-input-checkbox>
+        <app-input-checkbox
+          *ngIf="viewToEdit.chartType !== 'radar' && viewToEdit.options.XAxisGrid"
+          [disabled]="strippedGridHorizontal"
+          [id]="'chart-stripped-x'"
+          [(value)]="strippedGridVertical"
+          [color]="'primary'"
+          [label]="'Show stripped grid (alternate grid-lines)'"
+          [labelPosition]="'right'"
+          [classList]="'ml-6 -mt-2'"
+          (valueChange)="changeStripedGrid($event, 'vertical')"
+        ></app-input-checkbox>
+        <span *ngIf="strippedGridHorizontal" class="text-warning">You can only have one stripped grid in chart</span>
       </div>
 
-      <app-input-checkbox
-        [id]="'chart-x-grid'"
-        [(value)]="viewToEdit.options.XAxisGrid"
-        [color]="'primary'"
-        [label]="'Show grid on X-Axis'"
-        [labelPosition]="'right'"
-        [classList]="'mt-4'"
-      ></app-input-checkbox>
-      <app-input-checkbox
-        *ngIf="viewToEdit.chartType !== 'radar' && viewToEdit.options.XAxisGrid"
-        [disabled]="strippedGridHorizontal"
-        [id]="'chart-stripped-x'"
-        [(value)]="strippedGridVertical"
-        [color]="'primary'"
-        [label]="'Show stripped grid (alternate grid-lines)'"
-        [labelPosition]="'right'"
-        [classList]="'ml-6 -mt-2'"
-        (valueChange)="changeStripedGrid($event, 'vertical')"
-      ></app-input-checkbox>
-      <span *ngIf="strippedGridHorizontal" class="text-warning">You can only have one stripped grid in chart</span>
+      <div class="px-4" *ngIf="viewToEdit.chartType !== 'radar'"> <!-------------- Y AXIS ------------------->
+        <app-input-text
+          [id]="'chart-y-label'"
+          [(value)]="viewToEdit.options.YAxisLabel"
+          [placeholder]="'e.g. \'XP Evolution\' '"
+          [required]="false"
+          [topLabel]="'Y-Axis label'"
+        ></app-input-text>
+        <app-input-number
+          [id]="'chart-y-ticks'"
+          [(value)]="viewToEdit.options.YAxisTickAmount"
+          [topLabel]="'Y-Axis amount of ticks'"
+          [helperText]="'Determine approximately the number of ticks (grid-lines) displayed on the Y-axis of the chart. It helps to improve readability.'"
+          [helperPosition]="'right'"
+          [placeholder]="'Select a number'"
+        ></app-input-number>
+        <app-input-number
+          [id]="'chart-y-min'"
+          [(value)]="viewToEdit.options.YAxisMin"
+          [topLabel]="'Y-Axis minimum value'"
+          [placeholder]="'Select a minimum number'"
+        ></app-input-number>
+        <app-input-number
+          [id]="'chart-y-max'"
+          [(value)]="viewToEdit.options.YAxisMax"
+          [topLabel]="'Y-Axis maximum value'"
+          [placeholder]="'Select a maximum number'"
+        ></app-input-number>
+        <app-input-checkbox
+          [id]="'block-responsive'"
+          [(value)]="viewToEdit.options.YAxisReversed"
+          [color]="'primary'"
+          [label]="'Reverse Y-Axis values'"
+          [labelPosition]="'right'"
+          [classList]="'mt-4'"
+        ></app-input-checkbox>
+        <span class="ml-6 -mt-4 text-sm">(Instead of being ordered from bottom to top change from top to bottom)</span>
+        <app-input-checkbox
+          [id]="'chart-y-grid'"
+          [(value)]="viewToEdit.options.YAxisGrid"
+          [color]="'primary'"
+          [label]="'Show grid on Y-Axis'"
+          [labelPosition]="'right'"
+          [classList]="'mt-4'"
+        ></app-input-checkbox>
+        <app-input-checkbox
+          *ngIf="viewToEdit.options.YAxisGrid"
+          [disabled]="strippedGridVertical"
+          [id]="'chart-stripped-y'"
+          [(value)]="strippedGridHorizontal"
+          [color]="'primary'"
+          [label]="'Show stripped grid (alternate grid-lines)'"
+          [labelPosition]="'right'"
+          [classList]="'ml-6 -mt-2'"
+          (valueChange)="changeStripedGrid($event, 'horizontal')"
+        ></app-input-checkbox>
+        <span *ngIf="strippedGridVertical" class="text-warning">You can only have one stripped grid in chart</span>
+      </div>
+      <div class="px-4" *ngIf="viewToEdit.chartType === 'radar'">
+        <app-input-checkbox
+          [id]="'chart-normalized'"
+          [(value)]="viewToEdit.options.normalized"
+          [color]="'primary'"
+          [label]="'Normalize data series'"
+          [labelPosition]="'right'"
+        ></app-input-checkbox>
+      </div>
     </div>
-
-    <div class="px-4" *ngIf="viewToEdit.chartType !== 'radar'"> <!-------------- Y AXIS ------------------->
-      <app-input-text
-        [id]="'chart-y-label'"
-        [(value)]="viewToEdit.options.YAxisLabel"
-        [placeholder]="'e.g. \'XP Evolution\' '"
-        [required]="false"
-        [topLabel]="'Y-Axis label'"
-      ></app-input-text>
-      <app-input-number
-        [id]="'chart-y-ticks'"
-        [(value)]="viewToEdit.options.YAxisTickAmount"
-        [topLabel]="'Y-Axis amount of ticks'"
-        [helperText]="'Determine approximately the number of ticks (grid-lines) displayed on the Y-axis of the chart. It helps to improve readability.'"
-        [helperPosition]="'right'"
-        [placeholder]="'Select a number'"
-      ></app-input-number>
-      <app-input-number
-        [id]="'chart-y-min'"
-        [(value)]="viewToEdit.options.YAxisMin"
-        [topLabel]="'Y-Axis minimum value'"
-        [placeholder]="'Select a minimum number'"
-      ></app-input-number>
-      <app-input-number
-        [id]="'chart-y-max'"
-        [(value)]="viewToEdit.options.YAxisMax"
-        [topLabel]="'Y-Axis maximum value'"
-        [placeholder]="'Select a maximum number'"
-      ></app-input-number>
-      <app-input-checkbox
-        [id]="'block-responsive'"
-        [(value)]="viewToEdit.options.YAxisReversed"
-        [color]="'primary'"
-        [label]="'Reverse Y-Axis values'"
-        [labelPosition]="'right'"
-        [classList]="'mt-4'"
-      ></app-input-checkbox>
-      <span class="ml-6 -mt-4 text-sm">(Instead of being ordered from bottom to top change from top to bottom)</span>
-      <app-input-checkbox
-        [id]="'chart-y-grid'"
-        [(value)]="viewToEdit.options.YAxisGrid"
-        [color]="'primary'"
-        [label]="'Show grid on Y-Axis'"
-        [labelPosition]="'right'"
-        [classList]="'mt-4'"
-      ></app-input-checkbox>
-      <app-input-checkbox
-        *ngIf="viewToEdit.options.YAxisGrid"
-        [disabled]="strippedGridVertical"
-        [id]="'chart-stripped-y'"
-        [(value)]="strippedGridHorizontal"
-        [color]="'primary'"
-        [label]="'Show stripped grid (alternate grid-lines)'"
-        [labelPosition]="'right'"
-        [classList]="'ml-6 -mt-2'"
-        (valueChange)="changeStripedGrid($event, 'horizontal')"
-      ></app-input-checkbox>
-      <span *ngIf="strippedGridVertical" class="text-warning">You can only have one stripped grid in chart</span>
-    </div>
-    <div class="px-4" *ngIf="viewToEdit.chartType === 'radar'"> <!-------------- Y AXIS ------------------->
-      <app-input-checkbox
-        [id]="'chart-normalized'"
-        [(value)]="viewToEdit.options.normalized"
-        [color]="'primary'"
-        [label]="'Normalize data series'"
-        [labelPosition]="'right'"
-      ></app-input-checkbox>
-    </div>
-  </div>
+  </ng-container>
 
   <div class="flex flex-row mt-4 justify-start items-center gap-2">
     <span class="block font-semibold text-mg pl-1">Data Tooltips</span>
@@ -965,7 +969,7 @@
   </div>
   
   <!-- BAR CHART EXTRAS -->
-  <div *ngIf="viewToEdit.chartType === 'bar'" class="grid grid-cols-2 gap-8">
+  <div *ngIf="viewToEdit.chartType === 'bar' || viewToEdit.chartType === 'combo'" class="grid grid-cols-2 gap-8">
     <div>
       <div class="flex flex-row mt-2 justify-start items-center gap-2">
         <span class="block font-semibold text-md">Bars orientation</span>
@@ -1015,6 +1019,51 @@
     ></app-input-number>
   </div>
 
+  <!-- PIE CHART EXTRAS -->
+  <ng-container *ngIf="viewToEdit.chartType === 'pie'">
+    <div class="grid grid-cols-2 mb-4">
+      <div class="border-r-2 border-neutral/10 px-4">
+        <app-input-number
+          [id]="'chart-pie-start-angle'"
+          [(value)]="viewToEdit.options.startAngle"
+          [topLabel]="'Custom start angle'"
+          [placeholder]="'Select a number (from 0 to 360)'"
+          [helperText]="'Custom angle from which the pie slices start. Default is 0.'"
+        ></app-input-number>
+        <app-input-number
+          [id]="'chart-pie-end-angle'"
+          [(value)]="viewToEdit.options.endAngle"
+          [topLabel]="'Custom end angle'"
+          [placeholder]="'Select a number (from 0 to 360)'"
+          [helperText]="'Custom angle from which the pie slices end. Default is 360.'"
+        ></app-input-number>
+      </div>
+      <div class="px-4">
+        <app-input-number
+          [id]="'chart-pie-x-offset'"
+          [(value)]="viewToEdit.options.offsetX"
+          [topLabel]="'Custom x-offset'"
+          [placeholder]="'Select a number'"
+          [helperText]="'Sets left offset to the entire pie chart area.'"
+        ></app-input-number>
+        <app-input-number
+          [id]="'chart-pie-y-offset'"
+          [(value)]="viewToEdit.options.offsetY"
+          [topLabel]="'Custom y-ofset'"
+          [placeholder]="'Select a number'"
+          [helperText]="'Sets top offset to the entire pie chart area.'"
+        ></app-input-number>
+      </div>
+    </div>
+    <app-input-checkbox
+      [id]="'chart-pie-expandOnClick'"
+      [(value)]="viewToEdit.options.expandOnClick"
+      [color]="'primary'"
+      [label]="'Expand visually slice when clicked'"
+      [labelPosition]="'right'"
+    ></app-input-checkbox>
+  </ng-container>
+
   <!-- <div class="grid grid-cols-2"> -->
     <app-input-checkbox
       [id]="'chart-sparkline'"
@@ -1023,7 +1072,7 @@
       [label]="'Create spark-line of graph (hide everything but primary paths)'"
       [labelPosition]="'right'"
     ></app-input-checkbox>
-    <!-- TODO : extra for line chart - toolbar actions
+    <!-- TODO : toolbar actions
     <div>
       <app-input-checkbox
         [id]="'chart-toolbar'"

--- a/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.html
+++ b/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.html
@@ -1,6 +1,5 @@
-<ng-container *ngIf="viewToEdit.type !== ViewType.TABLE && viewToEdit.type !== ViewType.CHART" [ngTemplateOutlet]="GENERIC_EDITOR"></ng-container>
+<ng-container *ngIf="viewToEdit.type !== ViewType.TABLE" [ngTemplateOutlet]="GENERIC_EDITOR"></ng-container>
 <ng-container *ngIf="viewToEdit.type === ViewType.TABLE" [ngTemplateOutlet]="TABLE_EDITOR"></ng-container>
-<ng-container *ngIf="viewToEdit.type === ViewType.CHART" [ngTemplateOutlet]="CHART_EDITOR"></ng-container>
 
 
 <!--------------------------------------------------->
@@ -20,6 +19,10 @@
     [required]="true"
     [classList]="'mb-4'">
   </app-input-select>
+
+  <!--------------------- Chart options ---------------------->
+  <ng-container *ngIf="viewToEdit.type === ViewType.CHART" [ngTemplateOutlet]="CHART_EDITOR"></ng-container>
+
   <!--------------------- Button options --------------------->
   <ng-container *ngIf="viewToEdit.type === ViewType.BUTTON">
     <div class="flex flex-row mt-2 justify-start items-center gap-2">
@@ -143,7 +146,7 @@
       [id]="'component-icon'"
       [(value)]="viewToEdit.size"
       [options]="getIconSizeOptions()"
-      [placeholder]="'Select component type'"
+      [placeholder]="'Select size'"
       [topLabel]="'Select size for your icon'"
       [helperText]="'Will display the icon bigger or smaller. Default is medium size.'"
       [helperPosition]="'right'"
@@ -596,8 +599,143 @@
     [(value)]="viewToEdit.chartType"
     [options]="getChartTypes()"
     [placeholder]="'Select chart type'"
-    [topLabel]="'Chart Type'"
+    [topLabel]="'Type of Chart'"
     [required]="true"
     [classList]="'mb-4'">
   </app-input-select>
+
+  <div class="flex flex-row mt-2 justify-start items-center gap-2">
+    <span class="block font-semibold text-mg pl-1">Dimensions</span>
+  </div>
+  <div class="text-xs pl-1 pb-2">
+    Not mandatory, only specify if needed. Default are width = 100% and height = 'auto'.
+  </div>
+  <div class="flex flex-row gap-2">
+    <app-input-text
+      [id]="'chart-width'"
+      [(value)]="viewToEdit.options.width"
+      [placeholder]="'e.g. 80%'"
+      [required]="false"
+      [leftLabel]="'Width '"
+      [size]="'sm'">
+    </app-input-text>
+    <app-input-text
+      [id]="'chart-height'"
+      [(value)]="viewToEdit.options.height"
+      [placeholder]="'e.g. 80%'"
+      [required]="false"
+      [leftLabel]="'Height'"
+      [size]="'sm'">
+    </app-input-text>
+  </div>
+
+  <div class="flex flex-row gap-10 mt-2">
+    <div class="w-1/2 shrink-0">
+      <div class="flex flex-row my-2 justify-start items-center gap-2">
+        <app-simple-helper [position]="'right'" [text]="'Series of data to display in chart.'"></app-simple-helper>
+        <span class="block font-semibold text-mg">Chart Data</span>
+      </div>
+      <app-input-text
+        [id]="'chart-data'"
+        [(value)]="viewToEdit.data"
+        [placeholder]="'e.g. { providers.XPEvolution(%item.id, \'day\') }'"
+        [required]="true">
+      </app-input-text>
+    </div>
+    <div class="grow">
+      <app-input-color
+        [id]="'chart-colors'"
+        [(value)]="viewToEdit.color"
+        [(values)]="viewToEdit.options.colors"
+        [placeholder]="'Chart Colors'"
+        [topLabel]="'Chart Colors'"
+        [helperText]="'Choose colors for each set of the data series.'"
+        [helperPosition]="'right'"
+        [multiple]="true">
+      </app-input-color>
+    </div>
+  </div>
+
+<!--   <div class="flex flex-row mt-2 justify-start items-center gap-2">
+    <span class="block font-semibold text-mg pl-1">Data Labels</span>
+  </div>
+  <div class="text-xs pl-1 pb-2">
+    Textual or numeric labels that are associated with individual data points or series on the chart. They provide additional information about the data being displayed, making it easier for viewers to interpret the chart.
+  </div>
+  <app-input-checkbox
+    [id]="'block-responsive'"
+    [(value)]="viewToEdit.options."
+    [color]="'primary'"
+    (valueChange)="viewToEdit.responsive = !viewToEdit.responsive"
+    [label]="'Add data labels to this chart'"
+    [labelPosition]="'right'">
+  </app-input-checkbox> -->
+
+  <div class="flex flex-row mt-4 justify-start items-center gap-2">
+    <span class="block font-semibold text-mg pl-1">Axis</span>
+  </div>
+  <div class="flex flex-row">
+    <div class="grow border-r-2 border-neutral/10 px-4">
+      <app-input-text
+        [id]="'chart-x-label'"
+        [(value)]="viewToEdit.options.XAxisLabel"
+        [placeholder]="'e.g. \'Time (days)\' '"
+        [required]="false"
+        [topLabel]="'X-Axis label'"
+      ></app-input-text>
+      <app-input-number
+        [id]="'chart-x-ticks'"
+        [(value)]="viewToEdit.options.XAxisTickAmount"
+        [topLabel]="'X-Axis amount of ticks'"
+        [helperText]="'Determine approximately the number of ticks (grid-lines) displayed on the X-axis of the chart. It helps to improve readability.'"
+        [helperPosition]="'right'"
+      ></app-input-number>
+      <app-input-select
+        [id]="'chart-x-type'"
+        [(value)]="viewToEdit.options.XAxisType"
+        [options]="getXAxisDataTypes()"
+        [placeholder]="'Select X-Axis data type'"
+        [topLabel]="'X-Axis type of data'"
+        [required]="false"
+      ></app-input-select>
+    </div>
+    <div class="grow px-4">
+      <app-input-text
+        [id]="'chart-y-label'"
+        [(value)]="viewToEdit.options.YAxisLabel"
+        [placeholder]="'e.g. \'XP Evolution\' '"
+        [required]="false"
+        [topLabel]="'Y-Axis label'"
+      ></app-input-text>
+      <app-input-number
+        [id]="'chart-y-ticks'"
+        [(value)]="viewToEdit.options.YAxisTickAmount"
+        [topLabel]="'Y-Axis amount of ticks'"
+        [helperText]="'Determine approximately the number of ticks (grid-lines) displayed on the Y-axis of the chart. It helps to improve readability.'"
+        [helperPosition]="'right'"
+        [placeholder]="'Select a number'"
+      ></app-input-number>
+      <app-input-number
+        [id]="'chart-y-min'"
+        [(value)]="viewToEdit.options.YAxisMin"
+        [topLabel]="'Y-Axis minimum value'"
+        [placeholder]="'Select a minimum number'"
+      ></app-input-number>
+      <app-input-number
+        [id]="'chart-y-max'"
+        [(value)]="viewToEdit.options.YAxisMax"
+        [topLabel]="'Y-Axis maximum value'"
+        [placeholder]="'Select a maximum number'"
+      ></app-input-number>
+      <app-input-checkbox
+        [id]="'block-responsive'"
+        [(value)]="viewToEdit.options.YAxisReversed"
+        [color]="'primary'"
+        (valueChange)="switchYAxisReversed()"
+        [label]="'Reverse Y-Axis values'"
+        [labelPosition]="'right'"
+      ></app-input-checkbox>
+    </div>
+  </div>
+
 </ng-template>

--- a/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.html
+++ b/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.html
@@ -73,29 +73,23 @@
       To write expressions, make sure you encapsulate them with curly brackets: {{ '{' }} {{ '}' }}
       For more information check the 'Additional Tools' box.
     </div>
-    <div class="flex flex-row gap-10">
-      <div class="flex flex-col grow">
-        <div class="flex flex-row mt-2 justify-start items-center gap-2">
-          <app-simple-helper [position]="'right'" [text]="'Text that will be displayed'"></app-simple-helper>
-          <span class="block font-semibold text-lg">Text</span>
-        </div>
-        <app-input-text
-          [id]="'component-text'"
-          [(value)]="viewToEdit.text"
-          [required]="false">
-        </app-input-text>
-      </div>
-      <div class="flex flex-col grow">
-        <div class="flex flex-row mt-2 justify-start items-center gap-2">
-          <app-simple-helper [position]="'right'" [text]="'Enables link when clicked'"></app-simple-helper>
-          <span class="block font-semibold text-lg">Link</span>
-        </div>
-        <app-input-text
-          [id]="'component-link'"
-          [(value)]="viewToEdit.link"
-          [required]="false">
-        </app-input-text>
-      </div>
+    <div class="grid grid-cols-2 gap-8">
+      <app-input-text
+        [id]="'component-text'"
+        [(value)]="viewToEdit.text"
+        [required]="false"
+        [topLabel]="'Text'"
+        [helperText]="'Text that will be displayed'"
+        [helperPosition]="'right'"
+      ></app-input-text>
+      <app-input-text
+        [id]="'component-link'"
+        [(value)]="viewToEdit.link"
+        [required]="false"
+        [topLabel]="'Link'"
+        [helperText]="'Enables link when clicked'"
+        [helperPosition]="'right'"
+      ></app-input-text>
     </div>
   </ng-container>
 
@@ -106,29 +100,23 @@
       To write expressions, make sure you encapsulate them with curly brackets: {{ '{' }} {{ '}' }}
       For more information check the 'Additional Tools' box.
     </div>
-    <div class="flex flex-row gap-10">
-      <div class="flex flex-col grow">
-        <div class="flex flex-row mt-2 justify-start items-center gap-2">
-          <app-simple-helper [position]="'right'" [text]="'Source of the image that will be displayed'"></app-simple-helper>
-          <span class="block font-semibold text-lg">Source</span>
-        </div>
-        <app-input-text
-          [id]="'component-source'"
-          [(value)]="viewToEdit.src"
-          [required]="true">
-        </app-input-text>
-      </div>
-      <div class="flex flex-col grow">
-        <div class="flex flex-row mt-2 justify-start items-center gap-2">
-          <app-simple-helper [position]="'right'" [text]="'Enables link when clicked'"></app-simple-helper>
-          <span class="block font-semibold text-lg">Link</span>
-        </div>
-        <app-input-text
-          [id]="'component-link'"
-          [(value)]="viewToEdit.link"
-          [required]="false">
-        </app-input-text>
-      </div>
+    <div class="grid grid-cols-2 gap-8">
+      <app-input-text
+        [id]="'component-source'"
+        [(value)]="viewToEdit.src"
+        [required]="false"
+        [topLabel]="'Source'"
+        [helperText]="'Source of the image that will be displayed'"
+        [helperPosition]="'right'"
+      ></app-input-text>
+      <app-input-text
+        [id]="'component-link'"
+        [(value)]="viewToEdit.link"
+        [required]="false"
+        [topLabel]="'Link'"
+        [helperText]="'Enables link when clicked'"
+        [helperPosition]="'right'"
+      ></app-input-text>
     </div>
   </ng-container>
 
@@ -385,8 +373,8 @@
       <app-simple-helper [position]="'right'" [text]="'Use this section to style how the component should look like'"></app-simple-helper>
       <span class="block font-semibold text-lg">Interface Design</span>
     </div>
-    <div class="w-full flex flex-col md:flex-row gap-10">
-      <div class="md:w-1/2">
+    <div class="w-full h-full grid grid-cols-2 gap-8">
+      <div>
         <app-input-text
           [id]="'design-id'"
           [(value)]="viewToEdit.cssId"
@@ -409,7 +397,7 @@
           [helperPosition]="'right'"
         ></app-input-text>
       </div>
-      <div class="grow flex flex-col">
+      <div class="flex flex-col h-full">
         <div class="flex flex-row items-center mb-2">
           <span class="block font-semibold pl-1 py-1">Preview</span>
           <button class="ml-auto btn btn-sm btn-secondary" (click)="reloadPreview()">
@@ -674,8 +662,8 @@
   <div class="flex flex-row mt-4 justify-start items-center gap-2">
     <span class="block font-semibold text-mg pl-1">Axis</span>
   </div>
-  <div class="flex flex-row">
-    <div class="grow border-r-2 border-neutral/10 px-4">
+  <div class="grid grid-cols-2">
+    <div class="border-r-2 border-neutral/10 px-4">
       <app-input-text
         [id]="'chart-x-label'"
         [(value)]="viewToEdit.options.XAxisLabel"
@@ -698,8 +686,48 @@
         [topLabel]="'X-Axis type of data'"
         [required]="false"
       ></app-input-select>
+
+      <div class="bg-base-300 rounded-xl p-4 mt-4">
+        <div class="flex flex-row justify-start items-center gap-2">
+          <app-simple-helper [position]="'right'" [text]="'Categories for each data series. They will be sorted in the order they were included.'"></app-simple-helper>
+          <span class="block font-semibold text-mg pl-1">Add categories</span>
+        </div>
+        <div class="flex flex-row gap-2 mb-2">
+          <div *ngFor="let cat of this.viewToEdit.options.XAxisCategories; index as i" class="flex flex-row bg-secondary text-white py-1 px-2 rounded-lg text-sm">
+            {{cat}}
+            <span (click)="removeXAxisCategory(i)" class="hover:cursor-pointer">❌</span>
+          </div>
+        </div>
+        <div class="flex flex-row gap-2">
+          <app-input-text
+            [id]="'chart-x-label'"
+            [(value)]="categoryToAdd"
+            [placeholder]="'Add a category'"
+            [required]="false"
+          ></app-input-text>
+          <button class="btn btn-secondary" (click)="addXAxisCategory()">Add</button>
+        </div>
+      </div>
+
+      <app-input-checkbox
+        [id]="'chart-x-grid'"
+        [(value)]="viewToEdit.options.XAxisGrid"
+        [color]="'primary'"
+        [label]="'Show grid on X-Axis'"
+        [labelPosition]="'right'"
+        [classList]="'mt-4'"
+      ></app-input-checkbox>
+      <app-input-checkbox
+        *ngIf="viewToEdit.options.XAxisGrid"
+        [id]="'chart-stripped'"
+        [(value)]="viewToEdit.options.stripedGrid"
+        [color]="'primary'"
+        [label]="'Show stripped grid (alternate grid-lines)'"
+        [labelPosition]="'right'"
+        [classList]="'ml-6 -mt-2'"
+      ></app-input-checkbox>
     </div>
-    <div class="grow px-4">
+    <div class="px-4">
       <app-input-text
         [id]="'chart-y-label'"
         [(value)]="viewToEdit.options.YAxisLabel"
@@ -731,10 +759,208 @@
         [id]="'block-responsive'"
         [(value)]="viewToEdit.options.YAxisReversed"
         [color]="'primary'"
-        (valueChange)="switchYAxisReversed()"
         [label]="'Reverse Y-Axis values'"
         [labelPosition]="'right'"
+        [classList]="'mt-4'"
       ></app-input-checkbox>
+      <span class="ml-6 -mt-4 text-sm">(Instead of being ordered from bottom to top change from top to bottom)</span>
+      <app-input-checkbox
+        [id]="'chart-y-grid'"
+        [(value)]="viewToEdit.options.YAxisGrid"
+        [color]="'primary'"
+        [label]="'Show grid on Y-Axis'"
+        [labelPosition]="'right'"
+        [classList]="'mt-4'"
+      ></app-input-checkbox>
+      <app-input-checkbox
+        *ngIf="viewToEdit.options.YAxisGrid"
+        [id]="'chart-stripped'"
+        [(value)]="viewToEdit.options.stripedGrid"
+        [color]="'primary'"
+        [label]="'Show stripped grid (alternate grid-lines)'"
+        [labelPosition]="'right'"
+        [classList]="'ml-6 -mt-2'"
+      ></app-input-checkbox>
+    </div>
+  </div>
+
+  <div class="flex flex-row mt-4 justify-start items-center gap-2">
+    <span class="block font-semibold text-mg pl-1">Data Tooltips</span>
+  </div>
+  <div class="text-xs pl-1 pb-2">
+    Small pop-up boxes that appear when you hover your mouse pointer over a data point. Tooltips are used to provide additional information about the data or element, helping users understand and interpret the chart more effectively.
+  </div>
+  <app-input-checkbox
+    [id]="'chart-tooltip'"
+    [(value)]="viewToEdit.options.tooltip"
+    [color]="'primary'"
+    [label]="'Add data tooltips to this chart'"
+    [labelPosition]="'right'"
+  ></app-input-checkbox>
+  <div *ngIf="viewToEdit.options.tooltip" class="bg-base-300 rounded-xl p-6 text-xs">
+    Make use of the points in the chart or write expressions if needed. <br>
+    To access points use this.x and this.y, which will access each point coordinates in the data series.<br><br>
+
+    Check the following example:<br>
+    For data series Serie1, with X-categories: 'Jan', 'Feb' and values:<br><br>
+
+    Serie1 = [10, 15]<br><br>
+
+    We can format the tooltips for X-axis to be: "The X value for " + this.x + " corresponds to Y value " + this.y + " in this series".<br><br>
+
+    Which would iterate through all data points in graph [ [10 , Jan] , [15 , Feb] , ... ]  and translate to:<br>
+    The X value for <strong>10</strong> corresponds to Y value <strong>Jan</strong>.<br>
+    The X value for <strong>15</strong> corresponds to Y value <strong>Feb</strong>.
+
+    <div class="flex flex-row mt-4">
+      <div class="grow border-r-2 border-neutral/10 pr-4">
+        <app-input-text
+          [id]="'chart-x-tooltip-format'"
+          [(value)]="viewToEdit.options.tooltipXFormatter"
+          [placeholder]="'e.g. \'X value:\' + this.x '"
+          [required]="false"
+          [topLabel]="'Format data tooltips for X values:'"
+        ></app-input-text>
+      </div>
+      <div class="grow pl-4">
+        <app-input-text
+          [id]="'chart-y-tooltip-format'"
+          [(value)]="viewToEdit.options.tooltipYFormatter"
+          [placeholder]="'e.g. \'Y value:\' + this.y '"
+          [required]="false"
+          [topLabel]="'Format data tooltips for Y values:'"
+        ></app-input-text>
+      </div>
+    </div>
+  </div>
+
+  <div class="grid grid-cols-2 mt-4">
+    <div class="border-r-2 border-neutral/10 px-4">
+      <div class="flex flex-row mt-4 justify-start items-center gap-2">
+        <span class="block font-semibold text-mg pl-1">Title, Subtitle & Alignment</span>
+      </div>
+      <app-input-text
+        [id]="'chart-title'"
+        [(value)]="viewToEdit.options.title"
+        [placeholder]="'e.g. Leaderboard, Profile graph, ... '"
+        [topLabel]="'Title'"
+        ></app-input-text>
+        <app-input-text
+        [id]="'chart-subtitle'"
+        [(value)]="viewToEdit.options.subtitle"
+        [placeholder]="'e.g. Each student\'s leaderboard graph'"
+        [topLabel]="'Subtitle'"
+      ></app-input-text>
+      <app-input-select
+        [id]="'chart-align'"
+        [(value)]="viewToEdit.options.align"
+        [options]="getChartAlignmentOptions()"
+        [placeholder]="'Select alignment'"
+        [topLabel]="'Alignment of title & subtitle'"
+        [required]="false"
+      ></app-input-select>
+    </div>
+    <div class="px-4">
+      <div class="flex flex-row mt-4 justify-start items-center gap-2">
+        <span class="block font-semibold text-mg pl-1">Legend</span>
+      </div>
+      <app-input-checkbox
+        [id]="'chart-legend'"
+        [(value)]="viewToEdit.options.legend"
+        [color]="'primary'"
+        [label]="'Show legend in graph'"
+        [labelPosition]="'right'"
+      ></app-input-checkbox>
+      <div *ngIf="viewToEdit.options.legend" class="bg-base-300 rounded-xl p-4 text-xs">
+        <app-input-select
+          [id]="'chart-legend-position'"
+          [(value)]="viewToEdit.options.legendPosition"
+          [options]="getChartLegendPositionOptions()"
+          [placeholder]="'Select position'"
+          [topLabel]="'Choose position for legend (in regards of graph itself)'"
+          [required]="false"
+          [search]="false"
+        ></app-input-select>
+      </div>
+    </div>
+  </div>
+
+  <div class="flex flex-row mt-8 justify-start items-center gap-2">
+    <span class="block font-semibold text-mg pl-1">Data display</span>
+  </div>
+  <div class="grid grid-cols-3 gap-2">
+    <div class="border-r-2 border-neutral/10 p-4">
+      <div class="bg-base-300 rounded-xl p-4">
+        <app-input-select
+          [id]="'chart-lines'"
+          [(value)]="viewToEdit.options.strokeCurve"
+          [options]="getChartStrokeCurveOptions()"
+          [placeholder]="'Select stroke curve'"
+          [topLabel]="'Type of lines'"
+          [required]="false"
+          [search]="false"
+        ></app-input-select>
+      </div>
+    </div>
+    <div class="border-r-2 border-neutral/10 p-4">
+      <div class="bg-base-300 rounded-xl p-4">
+        <app-input-select
+          [id]="'chart-ends'"
+          [(value)]="viewToEdit.options.strokeLineCap"
+          [options]="getChartLineCapOptions()"
+          [placeholder]="'Select line cap'"
+          [topLabel]="'Type of start and end of line'"
+          [required]="false"
+          [search]="false"
+        ></app-input-select>
+      </div>
+    </div>
+    <div class="p-4">
+      <app-input-number
+        [id]="'chart-line-width'"
+        [(value)]="viewToEdit.options.strokeWidth"
+        [topLabel]="'Width of lines'"
+        [placeholder]="'Select a maximum number'"
+      ></app-input-number>
+      <app-input-number
+        [id]="'chart-marker-size'"
+        [(value)]="viewToEdit.options.markersSize"
+        [topLabel]="'Data points marker size'"
+        [placeholder]="'Select a maximum number'"
+      ></app-input-number>
+    </div>
+  </div>
+
+  <div class="flex flex-row mt-4 justify-start items-center gap-2">
+    <span class="block font-semibold text-mg pl-1">Extras</span>
+  </div>
+  <div class="grid grid-cols-2">
+    <app-input-checkbox
+      [id]="'chart-sparkline'"
+      [(value)]="viewToEdit.options.sparkline"
+      [color]="'primary'"
+      [label]="'Create spark-line of graph (hide everything but primary paths)'"
+      [labelPosition]="'right'"
+    ></app-input-checkbox>
+    <div>
+      <app-input-checkbox
+        [id]="'chart-toolbar'"
+        [(value)]="viewToEdit.options.toolbar"
+        [color]="'primary'"
+        [label]="'Show toolbar with actions'"
+        [labelPosition]="'right'"
+      ></app-input-checkbox>
+      <div *ngIf="viewToEdit.options.toolbar" class="bg-base-300 rounded-xl p-4">
+        <app-input-select
+          [id]="'chart-toolbar-actions'"
+          [(value)]="viewToEdit.options.toolbarActions"
+          [options]="getChartLineCapOptions()"
+          [placeholder]="'Select action'"
+          [topLabel]="'Available actions'"
+          [required]="false"
+          [search]="false"
+        ></app-input-select>
+      </div>
     </div>
   </div>
 

--- a/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.ts
+++ b/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.ts
@@ -77,6 +77,8 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
       this.viewToPreview = _.cloneDeep(this.view);
       this.viewToPreview.switchMode(ViewMode.PREVIEW);
     }
+
+    console.log(this.view);
   }
 
   // Additional Tools --------------------------------------
@@ -267,6 +269,12 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
     return Object.values(ChartType).map((value) => { return ({ value: value, text: value.capitalize() }) })
   }
 
+  getXAxisDataTypes() {
+    return [{ value: "category", text: "Category" },
+      { value: "datetime", text: "Datetime" },
+      { value: "numeric", text: "Numeric" }];
+  }
+
   getCollapseIconOptions() {
     return Object.values(CollapseIcon).map((value) => { return ({ value: value, text: value.capitalize() }) });
   }
@@ -283,6 +291,17 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
     ]
   }
 
+  switchYAxisReversed() {
+    console.log(this.viewToEdit.options.YAxisReversed);
+    if (!this.viewToEdit.options.YAxisReversed) {
+      this.viewToEdit.options.YAxisReversed = true;
+    }
+    else {
+      this.viewToEdit.options.YAxisReversed = !this.viewToEdit.options.YAxisReversed;
+    }
+    console.log(this.viewToEdit.options.YAxisReversed);
+  }
+
   /*** --------------------------------------------- ***/
   /*** ------------------ Actions ------------------ ***/
   /*** --------------------------------------------- ***/
@@ -291,7 +310,7 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
     this.updateView(this.view, this.viewToEdit);
     
     // For aspects --------------------------------------
-    const viewsWithThis = viewsByAspect.filter((e) => !_.isEqual(selectedAspect, e.aspect) && e.view.findView(this.view.id));
+    const viewsWithThis = viewsByAspect.filter((e) => !_.isEqual(selectedAspect, e.aspect) && e.view?.findView(this.view.id));
     
     if (viewsWithThis.length > 0) {
       const lowerInHierarchy = viewsWithThis.filter((e) =>

--- a/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.ts
+++ b/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.ts
@@ -48,6 +48,9 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
 
   categoryToAdd?: string = "";
 
+  strippedGridHorizontal?: boolean = false;
+  strippedGridVertical?: boolean = false;
+
   additionalToolsTabs: (CodeTab | OutputTab | ReferenceManualTab)[];
   functions: CustomFunction[];
   ELfunctions: CustomFunction[];
@@ -195,6 +198,9 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
       viewToEdit.chartType = this.view.chartType;
       viewToEdit.data = this.view.data;
       viewToEdit.options = this.view.options;
+
+      if (viewToEdit.options.stripedGrid === 'vertical') this.strippedGridVertical = true;
+      else if (viewToEdit.options.stripedGrid === 'horizontal') this.strippedGridHorizontal = true;
     }
     return viewToEdit;
   }
@@ -398,6 +404,27 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
   
   deleteEvent(index: number) {
     this.viewToEdit.events.splice(index, 1);
+  }
+  
+  addDataLabel(event: { serie: string; format: string }) {
+    this.viewToEdit.options.dataLabelsOnSeries.push(event);
+  }
+  
+  updateDataLabel(event: { serie: string; format: string }, index: number) {
+    this.viewToEdit.options.dataLabelsOnSeries.splice(index, 1, event);
+  }
+  
+  deleteDataLabel(index: number) {
+    this.viewToEdit.options.dataLabelsOnSeries.splice(index, 1);
+  }
+
+  changeStripedGrid(event: boolean, orientation: string) {
+    if (event) {
+      this.viewToEdit.options.stripedGrid = orientation;
+    }
+    else {
+      this.viewToEdit.options.stripedGrid = null;
+    }
   }
 
   selectIcon(icon: string, required: boolean) {

--- a/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.ts
+++ b/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.ts
@@ -23,7 +23,7 @@ import { ApiHttpService } from "src/app/_services/api/api-http.service";
 import { moveItemInArray } from "@angular/cdk/drag-drop";
 import { ActivatedRoute } from "@angular/router";
 import { ChartType, ViewChart } from "src/app/_domain/views/view-types/view-chart";
-import { getFakeId, groupedChildren, selectedAspect } from "src/app/_domain/views/build-view-tree/build-view-tree";
+import { getFakeId, groupedChildren, selectedAspect, viewsDeleted } from "src/app/_domain/views/build-view-tree/build-view-tree";
 import { isMoreSpecific, viewsByAspect } from "../views-editor.component";
 
 @Component({
@@ -82,8 +82,6 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
       this.viewToPreview = _.cloneDeep(this.view);
       this.viewToPreview.switchMode(ViewMode.PREVIEW);
     }
-
-    console.log(this.view);
   }
 
   // Additional Tools --------------------------------------
@@ -209,7 +207,36 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
   /*** ------------------ Helpers ------------------ ***/
   /*** --------------------------------------------- ***/
 
-  updateView(to: View, from: ViewManageData) {
+  changeComponentType(view: View, type: ViewType): View {
+    let newView;
+    if (type === ViewType.BLOCK) {
+      newView = ViewBlock.getDefault(view.parent, view.viewRoot, view.id, view.aspect);
+    }
+    else if (type === ViewType.BUTTON) {
+      newView = ViewButton.getDefault(view.parent, view.viewRoot, view.id, view.aspect);
+    }
+    else if (type === ViewType.CHART) {
+      newView = ViewChart.getDefault(view.parent, view.viewRoot, view.id, view.aspect);
+    }
+    else if (type === ViewType.COLLAPSE) {
+      newView = ViewCollapse.getDefault(view.parent, view.viewRoot, view.id, view.aspect);
+    }
+    else if (type === ViewType.ICON) {
+      newView = ViewIcon.getDefault(view.parent, view.viewRoot, view.id, view.aspect);
+    }
+    else if (type === ViewType.IMAGE) {
+      newView = ViewImage.getDefault(view.parent, view.viewRoot, view.id, view.aspect);
+    }
+    else if (type === ViewType.TABLE) {
+      newView = ViewTable.getDefault(view.parent, view.viewRoot, view.id, view.aspect);
+    }
+    else if (type === ViewType.TEXT) {
+      newView = ViewText.getDefault(view.parent, view.viewRoot, view.id, view.aspect);
+    }
+    return newView;
+  }
+
+  updateView(to: View, from: ViewManageData): View {
     to.classList = from.classList;
     to.type = from.type;
     to.visibilityType = from.visibilityType;
@@ -263,6 +290,8 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
       to.data = from.data;
       to.options = from.options;
     }
+
+    return to;
   }
 
   get ViewType(): typeof ViewType {
@@ -270,7 +299,7 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
   }
 
   getComponentTypes() {
-    return Object.values(ViewType).map((value) => { return ({ value: value, text: value.capitalize() }) })
+    return Object.values(ViewType).filter(e => e !== ViewType.ROW).map((value) => { return ({ value: value, text: value.capitalize() }) })
   }
   
   getCollapseIconOptions() {
@@ -320,7 +349,18 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
   /*** --------------------------------------------- ***/
 
   async saveView() {
-    this.updateView(this.view, this.viewToEdit);
+    // Changing the type requires creating a new instance of the new class
+    // need to update all references
+    let changedType = false;
+    if (this.view.type != this.viewToEdit.type) {
+      this.view = this.changeComponentType(this.view, this.viewToEdit.type);
+      this.updateView(this.view, this.viewToEdit);
+      viewsByAspect.find((e) => _.isEqual(selectedAspect, e.aspect)).view.replaceView(this.view.id, this.view);
+      changedType = true;
+    }
+    else {
+      this.updateView(this.view, this.viewToEdit);
+    }
     
     // For aspects --------------------------------------
     const viewsWithThis = viewsByAspect.filter((e) => !_.isEqual(selectedAspect, e.aspect) && e.view?.findView(this.view.id));
@@ -331,17 +371,35 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
         || (e.aspect.userRole !== selectedAspect.userRole && isMoreSpecific(e.aspect.userRole, selectedAspect.userRole))
       );
       
+      // this view isn't used in any other version "above"
       if (viewsWithThis.filter((e) => !lowerInHierarchy.includes(e)).length == 0) {
-        // this view isn't used in any other version "above"
-        // no need to create a new id, keep it and just
+        console.log("above all");
+        // if the type changed need to delete the old one and create a new in backend
+        const oldId = this.view.id;
+        if (changedType) {
+          viewsDeleted.push(oldId);
+          this.view.id = getFakeId();
+          
+          let entry = groupedChildren.get(this.view.parent.id);
+          if (entry) {
+            const group = entry.find((e) => e.includes(oldId));
+            const index = group.findIndex((e) => e === oldId);
+            group.splice(index, 1, this.view.id);
+            groupedChildren.set(this.view.parent.id, entry);
+          }
+        }
+        // else no need to create a new id
+        
         // propagate the changes to the views lower in hierarchy
         for (let el of lowerInHierarchy) {
-          const view = el.view.findView(this.view.id);
-          this.updateView(view, this.viewToEdit);
+          const view = el.view.findView(oldId);
+          if (changedType) { view.parent.replaceView(oldId, this.view); }
+          else { this.updateView(view, this.viewToEdit); }
         }
       }
+
+      // this is a new view in the tree with a new id
       else {
-        // this is a new view in the tree with a new id
         const oldId = this.view.id;
         this.view.id = getFakeId();
         this.view.aspect = selectedAspect;
@@ -351,19 +409,36 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
           group.find((e) => e.includes(oldId)).push(this.view.id);
           groupedChildren.set(this.view.parent.id, group);
         }
-        else {
-          // this is the first child inserted
+        else { // this is the first child inserted
           groupedChildren.set(this.view.parent.id, [[this.view.id]]);
         }
 
         // propagate the changes to the views lower in hierarchy that have the oldId
         for (let el of lowerInHierarchy) {
-          const view = el.view.findView(oldId);
-          this.updateView(view, this.viewToEdit);
+          let view = el.view.findView(oldId);
+          if (changedType) { view.parent.replaceView(view.id, this.view); }
+          else { this.updateView(view, this.viewToEdit); }
+          view = el.view.findView(oldId);
           view.id = this.view.id;
           view.aspect = this.view.aspect;
         }
         // views above in the hierarchy keep the old version
+      }
+    }
+
+    // this view is the only that uses this component, but component type changed
+    // need to delete in backend and force creating new with new id
+    else if (changedType) {
+      const oldId = this.view.id;
+      viewsDeleted.push(oldId);
+      this.view.id = getFakeId();
+
+      let entry = groupedChildren.get(this.view.parent.id);
+      if (entry) {
+        const group = entry.find((e) => e.includes(oldId));
+        const index = group.findIndex((e) => e === oldId);
+        group.splice(index, 1, this.view.id);
+        groupedChildren.set(this.view.parent.id, entry);
       }
     }
 
@@ -372,7 +447,14 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
   }
 
   reloadPreview() {
-    this.updateView(this.viewToPreview, this.viewToEdit);
+    if (this.viewToPreview.type != this.viewToEdit.type) {
+      this.viewToPreview = this.changeComponentType(this.viewToPreview, this.viewToEdit.type);
+      this.updateView(this.viewToPreview, this.viewToEdit);
+      this.viewToPreview.switchMode(ViewMode.PREVIEW);
+    }
+    else {
+      this.updateView(this.viewToPreview, this.viewToEdit);
+    }
     this.show = false;
 
     setTimeout(() => {
@@ -457,20 +539,20 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
   }
   addBodyRow(index: number) {
     const rowId = getFakeId();
-    const newRow = ViewRow.getDefault(rowId, this.view, this.view.id, this.view.aspect, RowType.BODY);
+    const newRow = ViewRow.getDefault(rowId, this.view, this.view.viewRoot, this.view.aspect, RowType.BODY);
     const iterations = this.getNumberOfCols() == 0 ? 1 : this.getNumberOfCols();
     for (let i = 0; i < iterations; i++) {
-      const newCell = ViewText.getDefault(getFakeId(), rowId, newRow, selectedAspect, "Cell");
+      const newCell = ViewText.getDefault(newRow, this.view.viewRoot, rowId, selectedAspect, "Cell");
       newRow.children.push(newCell);
     }
     this.viewToEdit.bodyRows.splice(index, 0, newRow);
   }
   addHeaderRow(index: number) {
-    const rowId = getFakeId();;
-    const newRow = ViewRow.getDefault(rowId, this.view, this.view.id, this.view.aspect, RowType.HEADER);
+    const rowId = getFakeId();
+    const newRow = ViewRow.getDefault(rowId, this.view, this.view.viewRoot, this.view.aspect, RowType.HEADER);
     const iterations = this.getNumberOfCols() == 0 ? 1 : this.getNumberOfCols();
     for (let i = 0; i < iterations; i++) {
-      const newCell = ViewText.getDefault(getFakeId(), rowId, newRow, selectedAspect, "Header");
+      const newCell = ViewText.getDefault(newRow, this.view.viewRoot, rowId, selectedAspect, "Header");
       newRow.children.push(newCell);
     }
     this.viewToEdit.headerRows.splice(index, 0, newRow);
@@ -509,11 +591,11 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
   }
   addColumn(index: number) {
     if (this.viewToEdit.headerRows[0]) {
-      const newHeaderCell = ViewText.getDefault(getFakeId(), this.viewToEdit.headerRows[0].id, this.viewToEdit.headerRows[0], selectedAspect, "Header");
+      const newHeaderCell = ViewText.getDefault(this.viewToEdit.headerRows[0], this.view.viewRoot, getFakeId(), selectedAspect, "Header");
       this.viewToEdit.headerRows[0].children.splice(index, 0, newHeaderCell);
     }
     for (let row of this.viewToEdit.bodyRows) {
-      const newCell = ViewText.getDefault(getFakeId(), row.id, row, selectedAspect, "Cell");
+      const newCell = ViewText.getDefault(row, this.view.viewRoot, getFakeId(), selectedAspect, "Cell");
       row.children.splice(index, 0, newCell);
     }
   }

--- a/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.ts
+++ b/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/component-editor/component-editor.component.ts
@@ -46,6 +46,8 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
   cellToEdit?: View = null;
   rowToEdit?: ViewRow = null;
 
+  categoryToAdd?: string = "";
+
   additionalToolsTabs: (CodeTab | OutputTab | ReferenceManualTab)[];
   functions: CustomFunction[];
   ELfunctions: CustomFunction[];
@@ -265,16 +267,6 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
     return Object.values(ViewType).map((value) => { return ({ value: value, text: value.capitalize() }) })
   }
   
-  getChartTypes() {
-    return Object.values(ChartType).map((value) => { return ({ value: value, text: value.capitalize() }) })
-  }
-
-  getXAxisDataTypes() {
-    return [{ value: "category", text: "Category" },
-      { value: "datetime", text: "Datetime" },
-      { value: "numeric", text: "Numeric" }];
-  }
-
   getCollapseIconOptions() {
     return Object.values(CollapseIcon).map((value) => { return ({ value: value, text: value.capitalize() }) });
   }
@@ -291,15 +283,30 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
     ]
   }
 
-  switchYAxisReversed() {
-    console.log(this.viewToEdit.options.YAxisReversed);
-    if (!this.viewToEdit.options.YAxisReversed) {
-      this.viewToEdit.options.YAxisReversed = true;
-    }
-    else {
-      this.viewToEdit.options.YAxisReversed = !this.viewToEdit.options.YAxisReversed;
-    }
-    console.log(this.viewToEdit.options.YAxisReversed);
+  getChartTypes() {
+    return Object.values(ChartType).map((value) => { return ({ value: value, text: value.capitalize() }) })
+  }
+
+  getXAxisDataTypes() {
+    return [{ value: "category", text: "Category" },
+      { value: "datetime", text: "Datetime" },
+      { value: "numeric", text: "Numeric" }];
+  }
+
+  getChartLegendPositionOptions() {
+    return [{ value: "top", text: "Top" }, { value: "right", text: "Right" }, { value: "bottom", text: "Bottom" }, { value: "left", text: "Left" }]
+  }
+
+  getChartAlignmentOptions() {
+    return [{ value: "left", text: "Left" }, { value: "center", text: "Center" }, { value: "right", text: "Right" }]
+  }
+
+  getChartStrokeCurveOptions() {
+    return [{ value: "smooth", text: "Smooth" }, { value: "straight", text: "Straight" }, { value: "stepline", text: "Stepline" }]
+  }
+
+  getChartLineCapOptions() {
+    return [{ value: "butt", text: "Butt" }, { value: "square", text: "Square" }, { value: "round", text: "Round" }]
   }
 
   /*** --------------------------------------------- ***/
@@ -400,6 +407,20 @@ export class ComponentEditorComponent implements OnInit, OnChanges {
     else {
       this.viewToEdit.icon = this.viewToEdit.icon == icon ? null : icon;
     }
+  }
+
+  addXAxisCategory() {
+    if (this.viewToEdit.options.XAxisCategories) {
+      this.viewToEdit.options.XAxisCategories.push(this.categoryToAdd);
+    }
+    else {
+      this.viewToEdit.options.XAxisCategories = [this.categoryToAdd];
+    }
+    this.categoryToAdd = "";
+  }
+
+  removeXAxisCategory(index: number) {
+    this.viewToEdit.options.XAxisCategories.splice(index, 1);
   }
 
   // Exclusives for tables ---------------------

--- a/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/views-editor.component.html
+++ b/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/views-editor.component.html
@@ -134,13 +134,13 @@
                         </div>
                       </div>
 
-                      <!-- System components are divided into subcategories -->
+                      <!-- System components, divided into subcategories -->
                       <div *ngIf="getSelectedCategories().length > 0 && getSelectedCategories()[0]['type'] == 'System'" class="space-y-5">
                         <div *ngFor="let subcategory of getSubcategories()">
-                          <span class="ml-1 text-xs font-bold text-neutral/40 uppercase">{{subcategory}}</span>
+                          <span class="ml-1 text-xs font-bold text-neutral/40 uppercase">{{subcategory.category}}</span>
                           <div class="flex flex-wrap">
                             <div 
-                              *ngFor="let item of getComponentsOfSubcategory(subcategory)" 
+                              *ngFor="let item of subcategory.views" 
                               class="hover:cursor-pointer p-1"
                               (click)="addComponentToPage(item)"
                             >

--- a/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/views-editor.component.ts
+++ b/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/views-editor.component.ts
@@ -755,21 +755,22 @@ export class ViewsEditorComponent implements OnInit {
     }
     else if (action === 'Redo') {
     }
-    /*
     else if (action === 'Raw (default)') {
       this.previewMode = 'raw';
-      this.view = await this.api.renderPageInEditor(this.page.id).toPromise();
-      this.view.switchMode(ViewMode.EDIT);
-    }
-    else if (action === 'Final preview (real data)') {
-      this.previewMode = 'real';
-      this.view = await this.api.previewPage(this.page.id, this.view.aspect).toPromise();
+      const correspondentView = viewsByAspect.find((e) => _.isEqual(e.aspect, selectedAspect))?.view;
+      if (correspondentView) {
+        this.view = correspondentView;
+        if (this.view) this.view.switchMode(ViewMode.EDIT);
+      }
     }
     else if (action === 'Layout preview (mock data)') {
       this.previewMode = 'mock';
       this.view = await this.api.renderPageWithMockData(this.page.id).toPromise();
     }
-    */
+    else if (action === 'Final preview (real data)') {
+      this.previewMode = 'real';
+      this.view = await this.api.previewPage(this.page.id, this.view.aspect).toPromise();
+    }
   }
 
   /*** --------------------------------------------- ***/

--- a/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/views-editor.component.ts
+++ b/frontend/src/app/_views/restricted/courses/course/settings/views/views-editor/views-editor.component.ts
@@ -439,7 +439,7 @@ export class ViewsEditorComponent implements OnInit {
           items: [
             {
               type: 'System',
-              isSelected: false,
+              isSelected: true,
               helper: TypeHelper.SYSTEM,
               list: this.coreTemplates
             },

--- a/frontend/src/app/_views/restricted/courses/course/settings/views/views/views.component.html
+++ b/frontend/src/app/_views/restricted/courses/course/settings/views/views/views.component.html
@@ -155,7 +155,7 @@
           </div>
           <div class="divider rounded before:bg-base-200 after:bg-base-200 mb-0.5 -mt-1"></div>
           <div>
-            <p *ngIf="template.isPublic"><span class="text-xs font-bold uppercase">Shared on:</span> {{calculateDate(template.sharedTimestamp)}}</p>
+            <!-- <p *ngIf="template.isPublic"><span class="text-xs font-bold uppercase">Shared on:</span> {{calculateDate(template.sharedTimestamp)}}</p> -->
             <p *ngIf="!template.isSystem"><span class="text-xs font-bold uppercase">Last edited:</span> {{calculateDate(template.updateTimestamp)}}</p>
           </div>
         </div>

--- a/frontend/src/app/_views/restricted/courses/course/settings/views/views/views.component.html
+++ b/frontend/src/app/_views/restricted/courses/course/settings/views/views/views.component.html
@@ -54,10 +54,10 @@
               </button>
             </ng-container>
             <ng-template #defaultButton>
-              <button class="btn btn-sm btn-{{!page.isPublic ? 'secondary' : 'secondary-content'}} btn-circle hover:text-base-content tooltip tooltip-left"
+              <button class="btn btn-sm btn-{{!page.isVisible ? 'secondary' : 'secondary-content'}} btn-circle hover:text-base-content tooltip tooltip-left"
                       data-tip="Make visible/invisible" (click)="chooseAction('configure visibility', page)">
-                <ng-icon name="{{!page.isPublic ? 'tabler-eye' : 'tabler-eye-off'}}" size="1.3rem"
-                         class="{{getTheme() === 'light' ? 'text-white' : (!page.isPublic ? 'text-white' : 'text-dark')}}">
+                <ng-icon name="{{!page.isVisible ? 'tabler-eye' : 'tabler-eye-off'}}" size="1.3rem"
+                         class="{{getTheme() === 'light' ? 'text-white' : (!page.isVisible ? 'text-white' : 'text-black')}}">
                 </ng-icon>
               </button>
             </ng-template>
@@ -222,7 +222,7 @@
 <!-- Delete Modal -->
 <app-modal *ngIf="mode === 'delete' && pageToManage"
            [id]="'delete-page'"
-           [templateRef]="DELETE"
+           [templateRef]="DELETE_PAGE"
            [header]="mode?.capitalize() + ' page \'' + pageToManage.name + '\'?'"
            [closeBtnText]="'Cancel'"
            [submitBtnText]="'Delete'"
@@ -231,7 +231,7 @@
            (submitBtnClicked)="doAction()"
            (onClose)="resetChanges()">
 </app-modal>
-<ng-template #DELETE>
+<ng-template #DELETE_PAGE>
   <div class="w-full flex flex-wrap">
     <span>Are your sure you want to delete '<strong>{{pageToManage.name}}</strong>' page? This action <strong> cannot be undone</strong>.</span>
   </div>
@@ -247,13 +247,41 @@
       </div>
     </div>
   </div>
+</ng-template>
 
+<app-modal *ngIf="mode === 'delete' && templateToManage"
+           [id]="'delete-template'"
+           [templateRef]="DELETE_TEMPLATE"
+           [header]="mode?.capitalize() + ' template \'' + templateToManage.name + '\'?'"
+           [closeBtnText]="'Cancel'"
+           [submitBtnText]="'Delete'"
+           [submitBtnColor]="'error'"
+           [actionInProgress]="loading.action"
+           (submitBtnClicked)="doTemplateAction()"
+           (onClose)="resetChanges()">
+</app-modal>
+<ng-template #DELETE_TEMPLATE>
+  <div class="w-full flex flex-wrap">
+    <span>Are your sure you want to delete '<strong>{{templateToManage.name}}</strong>' template? This action <strong> cannot be undone</strong>.</span>
+  </div>
+
+  <div *ngIf="templateToManage.isPublic" class="justify-center flex">
+    <div class="alert alert-warning shadow-lg rounded-lg w-full mt-6">
+      <div>
+        <ng-icon [name]="'feather-alert-triangle'" size="1.2rem"></ng-icon>
+        <div class="ml-2.5">
+          <span>This template might be used by other courses at the moment. Deleting it would also
+            <strong>make it unavailable for them</strong>.</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </ng-template>
 
 <!-- Make public / private modal -->
 <app-modal *ngIf="mode === 'make public-private' && pageToManage"
            [id]="'make-public-private-page'"
-           [templateRef]="MAKE_PUBLIC_PRIVATE"
+           [templateRef]="MAKE_PUBLIC_PRIVATE_PAGE"
            [header]="'Make \'' + pageToManage.name + '\' ' + (pageToManage.isPublic ? 'private' : 'public') + '?'"
            [closeBtnText]="'Cancel'"
            [submitBtnText]="'Yes'"
@@ -262,7 +290,7 @@
            (submitBtnClicked)="doAction()"
            (onClose)="resetChanges()">
 </app-modal>
-<ng-template #MAKE_PUBLIC_PRIVATE>
+<ng-template #MAKE_PUBLIC_PRIVATE_PAGE>
   <div *ngIf="pageToManage.course === course.id" class="flex flex-wrap -mt-1">
     <span class="w-full" *ngIf="pageToManage.isPublic">This page will <strong>stop being available</strong>
       for other courses. Do you wish to proceed?</span>
@@ -274,6 +302,33 @@
     <span class="w-full" *ngIf="pageToManage.isPublic"><strong>This page belongs to another course</strong>. Making it
       private will <strong>stop being available for this and other courses</strong>. Do you wish to proceed?</span>
     <span class="w-full" *ngIf="!pageToManage.isPublic">This page will be <strong>available for other courses to
+      use and modify.</strong> Do you wish to proceed?</span>
+  </div>
+</ng-template>
+
+<app-modal *ngIf="mode === 'make public-private' && templateToManage"
+           [id]="'make-public-private-template'"
+           [templateRef]="MAKE_PUBLIC_PRIVATE_TEMPLATE"
+           [header]="'Make \'' + templateToManage.name + '\' ' + (templateToManage.isPublic ? 'private' : 'public') + '?'"
+           [closeBtnText]="'Cancel'"
+           [submitBtnText]="'Yes'"
+           [submitBtnColor]="'error'"
+           [actionInProgress]="loading.action"
+           (submitBtnClicked)="doTemplateAction()"
+           (onClose)="resetChanges()">
+</app-modal>
+<ng-template #MAKE_PUBLIC_PRIVATE_TEMPLATE>
+  <div *ngIf="templateToManage.course === course.id" class="flex flex-wrap -mt-1">
+    <span class="w-full" *ngIf="templateToManage.isPublic">This template will <strong>stop being available</strong>
+      for other courses. Do you wish to proceed?</span>
+    <span class="w-full" *ngIf="!templateToManage.isPublic">This template will be <strong>available for other courses to
+      use and modify.</strong> Do you wish to proceed?</span>
+  </div>
+
+  <div *ngIf="templateToManage.course !== course.id" class="flex flex-wrap -mt-1">
+    <span class="w-full" *ngIf="templateToManage.isPublic"><strong>This template belongs to another course</strong>. Making it
+      private will <strong>stop being available for this and other courses</strong>. Do you wish to proceed?</span>
+    <span class="w-full" *ngIf="!templateToManage.isPublic">This template will be <strong>available for other courses to
       use and modify.</strong> Do you wish to proceed?</span>
   </div>
 </ng-template>
@@ -360,8 +415,8 @@
 
 <!-- Rename modal -->
 <app-modal *ngIf="mode === 'rename' && pageToManage"
-           [id]="'rename'"
-           [templateRef]="RENAME"
+           [id]="'rename-page'"
+           [templateRef]="RENAME_PAGE"
            [header]="'Rename \'' + pageName + '\''"
            [closeBtnText]="'Cancel'"
            [submitBtnText]="'Save'"
@@ -370,7 +425,7 @@
            (submitBtnClicked)="fPage.onSubmit(null); doAction()"
            (onClose)="resetChanges()">
 </app-modal>
-<ng-template #RENAME>
+<ng-template #RENAME_PAGE>
   <form #fPage="ngForm">
     <app-input-text
       [id] = "'page-name'"
@@ -385,7 +440,35 @@
       [maxLength]="60"
       [maxLengthErrorMessage]="'Page name is too long: maximum of 60 characters'">
     </app-input-text>
+  </form>
+</ng-template>
 
+<app-modal *ngIf="mode === 'rename' && templateToManage"
+           [id]="'rename-template'"
+           [templateRef]="RENAME_TEMPLATE"
+           [header]="'Rename \'' + templateName + '\''"
+           [closeBtnText]="'Cancel'"
+           [submitBtnText]="'Save'"
+           [submitBtnColor]="'primary'"
+           [actionInProgress]="loading.action"
+           (submitBtnClicked)="fTemplate.onSubmit(null); doTemplateAction()"
+           (onClose)="resetChanges()">
+</app-modal>
+<ng-template #RENAME_TEMPLATE>
+  <form #fTemplate="ngForm">
+    <app-input-text
+      [id] = "'template-name'"
+      [form] = "fTemplate"
+      [classList]="'w-full flex flex-wrap'"
+      [(value)] = "templateToManage.name"
+      [placeholder]="'Template name'"
+      [topLabel]="'New name'"
+      [pattern]="'(?!^\\d+$)^.+$'"
+      [patternErrorMessage]="'Template name can\'t be composed of only numbers'"
+      [required]="true"
+      [maxLength]="60"
+      [maxLengthErrorMessage]="'Template name is too long: maximum of 60 characters'">
+    </app-input-text>
   </form>
 </ng-template>
 

--- a/frontend/src/app/_views/restricted/courses/course/settings/views/views/views.component.ts
+++ b/frontend/src/app/_views/restricted/courses/course/settings/views/views/views.component.ts
@@ -19,6 +19,7 @@ import {Moment} from "moment";
 import {DownloadManager} from "../../../../../../../_utils/download/download-manager";
 import {ResourceManager} from "../../../../../../../_utils/resources/resource-manager";
 import { Template } from 'src/app/_domain/views/templates/template';
+import { User } from 'src/app/_domain/users/user';
 
 @Component({
   selector: 'app-views',
@@ -47,6 +48,7 @@ export class ViewsComponent implements OnInit {
   publicTemplates: Template[];    // Templates from other courses that are public
 
   pageToManage: PageManageData;
+  templateToManage: TemplateManageData;
   publicPagesCourses: {[publicPageId: number]: string} = {};  // Names from public pages' courses
   mode: 'import-pc' | 'import-gc' | 'rename' | 'arrange' | 'delete' | 'remove page' | 'visibility' | 'make public-private' | 'duplicate';
 
@@ -70,16 +72,16 @@ export class ViewsComponent implements OnInit {
       'accent' | 'accent-content' | 'neutral' | 'neutral-content' | 'info' | 'info-content' |
       'success' | 'success-content' | 'warning' | 'warning-content' | 'error' | 'error-content'  }[] =
     [{ icon: 'jam-pencil-f', description: 'Edit', type: 'edit', color: 'warning' },
-     //{ icon: 'feather-type', description: 'Rename', type: 'management' },
+     { icon: 'feather-type', description: 'Rename', type: 'management' },
      //{ icon: 'tabler-eye', description: 'Preview', type: 'management' },
-     //{ icon: 'jam-padlock-f', description: 'Make public/private', type: 'configuration' },
-     //{ icon: 'feather-sliders', description: 'Configure visibility', type: 'configuration' },
-      //{ icon: 'jam-trash-f', description: 'Delete', type: 'configuration', color: 'error' }
+     { icon: 'jam-padlock-f', description: 'Make public/private', type: 'configuration' },
+     { icon: 'jam-trash-f', description: 'Delete', type: 'configuration', color: 'error' }
     ];
 
   visibilityCheckbox: boolean;                    // For 'configure-visibility' modal
   isHovered: {[pageId: number]: boolean} = {};    // Changes padlock icon when hovering
   pageName: string;                               // Auxiliar for page name ('rename' modal)
+  templateName: string;                           // Auxiliar for template name ('rename' modal)
 
   // DUPLICATE OPTIONS
   duplicateOptions: {name: string, char: string}[] = [
@@ -96,10 +98,13 @@ export class ViewsComponent implements OnInit {
   filteredTemplates: Template[] = [];           // Templates search
 
   @ViewChild('fPage', {static: false}) fPage: NgForm;   // Page form
+  @ViewChild('fTemplate', {static: false}) fTemplate: NgForm;   // Template form
 
   // Import action
   importData: {file: File, replace: boolean} = { file: null, replace: true };
-  @ViewChild('fImport', {static: false}) fImport: NgForm;
+  @ViewChild('fImport', { static: false }) fImport: NgForm;
+  
+  user: User;
 
   constructor(
     private api: ApiHttpService,
@@ -118,6 +123,7 @@ export class ViewsComponent implements OnInit {
     this.route.parent.params.subscribe(async params => {
       const courseID = parseInt(params.id);
       await this.getCourse(courseID);
+      await this.getLoggedUser();
       await this.getPages(courseID);
       await this.getTemplates(courseID);
 
@@ -132,6 +138,10 @@ export class ViewsComponent implements OnInit {
 
   async getCourse(courseID: number): Promise<void> {
     this.course = await this.api.getCourseById(courseID).toPromise();
+  }
+
+  async getLoggedUser(): Promise<void> {
+    this.user = await this.api.getLoggedUser().toPromise();
   }
 
   async getPages(courseID: number) {
@@ -158,14 +168,16 @@ export class ViewsComponent implements OnInit {
     this.systemTemplates = await this.api.getCoreTemplates().toPromise() as Template[]; // FIXME do I want to show these too?
     this.courseTemplates = await this.api.getCustomTemplates(courseID).toPromise() as Template[];
     this.publicTemplates = await this.api.getSharedTemplates().toPromise() as Template[];
-
+    this.calculateTemplates();
+  }
+  
+  calculateTemplates() {
     this.courseTemplates.forEach((temp) => {
       let item = this.publicTemplates.find(e => temp.id === e.id);
       if (item) {
         Object.assign(temp, item);
       }
     })
-
     this.templates = this.systemTemplates.concat(this.courseTemplates);
     this.templatesToShow = this.templates;
     this.filteredTemplates = this.templates;
@@ -236,21 +248,69 @@ export class ViewsComponent implements OnInit {
         await this.router.navigate(['pages/editor/template/' + template.id], { relativeTo: this.route.parent });
 
     } else if (action === 'rename') {
-      // TODO
-      //ModalService.openModal('rename');
+      this.mode = 'rename';
+      this.templateToManage = initTemplateToManage(this.course.id, template);
+      this.templateName = _.cloneDeep(this.templateToManage.name);
+      ModalService.openModal('rename-template');
 
     } else if (action === 'preview') {
       // TODO
 
     } else if (action === 'make public/private') {
-      // TODO
-      //ModalService.openModal('make-public-private-page')
+      this.templateToManage = initTemplateToManage(this.course.id, template);
+      this.mode = 'make public-private';
+      ModalService.openModal('make-public-private-template')
 
     } else if (action === 'delete') {
-      // TODO
-      //ModalService.openModal('delete-page');
+      this.templateToManage = initTemplateToManage(this.course.id, template);
+      this.mode = 'delete';
+      ModalService.openModal('delete-template');
     }
 
+  }
+
+  async doTemplateAction(){
+    const template = _.cloneDeep(this.templateToManage);
+    let origin: 'course' | 'public' = template.isPublic ? 'public' : 'course';
+
+    if (this.mode === 'make public-private') {
+      this.loading.action = true;
+
+      template.isPublic = !template.isPublic;
+      if (template.isPublic) {
+        await this.api.shareTemplate(template.id, this.course.id, this.user.id, "").toPromise(); // FIXME description
+      }
+      else {
+        await this.api.makePrivateTemplate(template.id, this.user.id).toPromise();
+      }
+      const newTemplate = await this.api.editTemplate(this.course.id, template).toPromise();
+      await this.updateTemplates('update', newTemplate, origin);
+
+      AlertService.showAlert(AlertType.SUCCESS, 'Template \'' + template.name + '\' ' +
+        (template.isPublic ? 'published' : 'make private'));
+      ModalService.closeModal('make-public-private-template');
+
+      this.loading.action = false;
+
+    } else if (this.mode === 'delete'){
+      this.loading.action = true;
+
+      await this.api.deleteCustomTemplate(template.id, this.course.id).toPromise();
+      await this.updateTemplates('remove', template, origin);
+
+      AlertService.showAlert(AlertType.SUCCESS, 'Template \'' + template.name + '\' deleted successfully.')
+      ModalService.closeModal('delete-template');
+
+      this.loading.action = false;
+    }
+    else {
+      const editedTemplate = await this.api.editTemplate(this.course.id, template).toPromise();
+      await this.updateTemplates('update', editedTemplate, origin);
+      if (this.mode === 'rename') {
+        AlertService.showAlert(AlertType.SUCCESS, 'Template \'' + template.name + '\' successfully renamed.');
+        ModalService.closeModal('rename-template');
+      }
+    }
   }
 
   async chooseAction(action:string, page: Page) {
@@ -263,7 +323,7 @@ export class ViewsComponent implements OnInit {
       this.mode = 'rename';
       this.pageToManage = initPageToManage(this.course.id, page);
       this.pageName = _.cloneDeep(this.pageToManage.name);
-      ModalService.openModal('rename');
+      ModalService.openModal('rename-page');
 
     } else if (action === 'preview') {
       // TODO
@@ -367,7 +427,7 @@ export class ViewsComponent implements OnInit {
 
           } else if (this.mode === 'rename') {
             AlertService.showAlert(AlertType.SUCCESS, 'Page \'' + page.name + '\' successfully renamed.');
-            ModalService.closeModal('rename');
+            ModalService.closeModal('rename-page');
 
           }
         }
@@ -404,10 +464,39 @@ export class ViewsComponent implements OnInit {
     this.pagesToShow = this.pages;
   }
 
+  async updateTemplates(option: 'update' | 'add' | 'remove' | 'remove or add', template: Template, origin: 'core' | 'course' | 'public') {
+    if (option === 'remove'){
+      const index = origin === 'course' ? this.courseTemplates.findIndex(myTemplate => myTemplate.id === template.id)
+        : this.publicTemplates.findIndex(myTemplate => myTemplate.id === template.id);
+
+      origin === 'course' ? this.courseTemplates.splice(index, 1) : this.publicTemplates.splice(index, 1);
+
+    } else if (option === 'add'){
+      origin === 'course' ? this.courseTemplates.push(template) : this.publicTemplates.push(template);
+
+    } else if (option === 'update') {
+      const index = origin === 'course' ? this.courseTemplates.findIndex(myTemplate => myTemplate.id === template.id)
+        : this.publicTemplates.findIndex(myTemplate => myTemplate.id === template.id);
+
+      origin === 'course' ? this.courseTemplates.splice(index, 1, template) : this.publicTemplates.splice(index, 1, template);
+
+    } else if (option === 'remove or add'){
+      const index = origin === 'course' ? this.courseTemplates.findIndex(myTemplate => myTemplate.id === template.id)
+        : this.publicTemplates.findIndex(myTemplate => myTemplate.id === template.id);
+
+      origin === 'course' ? this.courseTemplates.splice(index, 1, template) : this.publicTemplates.splice(index, 1);
+    }
+
+    this.calculateTemplates();
+  }
+
   resetChanges(){
     if (this.mode === 'arrange') this.arrangingPages = null;
     else if (this.mode === 'visibility') this.visibilityCheckbox = null;
-    else if (this.mode === 'rename') this.pageName = null;
+    else if (this.mode === 'rename') {
+      this.pageName = null;
+      this.templateName = null;
+    }
     else if (this.mode === 'duplicate') this.optionSelected = null;
     else if (this.mode === 'import-pc'){
       this.importData = {file: null, replace: true};
@@ -415,6 +504,7 @@ export class ViewsComponent implements OnInit {
     }
 
     this.pageToManage = null;
+    this.templateToManage = null;
     this.mode = null;
   }
 
@@ -518,6 +608,15 @@ export interface PageManageData {
   position?: number,
   isPublic?: boolean
 }
+export interface TemplateManageData {
+  id?: number,
+  name?: string,
+  course?: number,
+  viewRoot?: number,
+  creationTimestamp?: string,
+  updateTimestamp?: string,
+  isPublic?: boolean
+}
 
 export function initPageToManage(courseID: number, page?: Page): PageManageData {
   const pageData: PageManageData = {
@@ -534,4 +633,17 @@ export function initPageToManage(courseID: number, page?: Page): PageManageData 
   };
   if (page) pageData.id = page.id;
   return pageData;
+}
+
+export function initTemplateToManage(courseID: number, template?: Template): TemplateManageData {
+  const templateData: TemplateManageData = {
+    course: template?.course ?? courseID,
+    name: template?.name ?? null,
+    viewRoot: template?.viewRoot ?? null,
+    creationTimestamp: template?.creationTimestamp ? template.creationTimestamp.format('YYYY-MM-DD') : null,
+    updateTimestamp: template?.updateTimestamp ? template.updateTimestamp.format('YYYY-MM-DD') : null,
+    isPublic: template?.isPublic ?? false
+  };
+  if (template) templateData.id = template.id;
+  return templateData;
 }

--- a/frontend/src/app/shared.module.ts
+++ b/frontend/src/app/shared.module.ts
@@ -65,6 +65,7 @@ import { ModuleCardComponent } from './_components/cards/module-card/module-card
 import { AspectCardComponent } from './_components/cards/aspect-card/aspect-card.component';
 import { AuxVarCardComponent } from './_components/cards/aux-var-card/aux-var-card.component';
 import { EventCardComponent } from './_components/cards/event-card/event-card.component';
+import { DatalabelCardComponent } from './_components/cards/datalabel-card/datalabel-card.component';
 
 // Components: alerts
 import { AlertComponent } from './_components/alerts/alert/alert.component';
@@ -288,6 +289,7 @@ import {
     AspectCardComponent,
     AuxVarCardComponent,
     EventCardComponent,
+    DatalabelCardComponent,
 
     AlertComponent,
 
@@ -373,6 +375,7 @@ import {
     AspectCardComponent,
     AuxVarCardComponent,
     EventCardComponent,
+    DatalabelCardComponent,
 
     AlertComponent,
 


### PR DESCRIPTION
- Added most of the chart options. Missing some for progress charts, and images for guidance
- Fixed the bug where components would lose style configurations when entering editor after first time
- Fixed reordering of pages in sidebar
- Added more options for Templates in the main Pages page (renaming, delete, share/private)

Missing:
- Undo and Redo
- Previews (started looking into it, but only works for static pages with a single aspect)
- There seems to be a bug with the backend function that generates the tree for each different aspect on the editor, for an existing page (p.ex. Achiever version looks incomplete, without things from Student version. When creating a new page it looks fine tho, and it displays correctly for the student).