### PR TITLE
Roles, link to file and rule sections tweaks

### DIFF
--- a/frontend/src/app/_components/inputs/rich-text/input-rich-text/input-rich-text.component.ts
+++ b/frontend/src/app/_components/inputs/rich-text/input-rich-text/input-rich-text.component.ts
@@ -167,9 +167,10 @@ export class InputRichTextComponent implements OnInit, AfterViewInit {
     }
     else {
       const filename = file.path.split('/').slice(-1).join('/');
-
-      this.quill.insertText(range.index, filename, 'user');
-      this.quill.setSelection(range.index, filename.length);
+      if (range.length == 0) {
+        this.quill.insertText(range.index, filename, 'user');
+        this.quill.setSelection(range.index, filename.length);
+      }
       this.quill.theme.tooltip.edit('link', url);
       this.quill.theme.tooltip.save();
     }

--- a/frontend/src/app/_views/restricted/courses/course/settings/roles/roles.component.html
+++ b/frontend/src/app/_views/restricted/courses/course/settings/roles/roles.component.html
@@ -35,7 +35,7 @@
         <app-spinner [size]="'sm'" [color]="'primary-content'" [classList]="'mr-3'"></app-spinner>
       </ng-container>
 
-      Update roles
+      Save
     </button>
   </div>
 
@@ -65,8 +65,10 @@
             </div>
 
           <!-- Role -->
-          <div class="dd-content" [ngClass]="{'!border-primary !border-opacity-75 text-primary font-semibold': isDefaultRole(role.name) || isAdaptationRole(role.name)}">
-            {{role.name}}
+          <div class="dd-content flex flex-row" [ngClass]="{'!border-primary !border-opacity-75 text-primary font-semibold': isDefaultRole(role.name) || isAdaptationRole(role.name)}">
+            <span>{{role.name}}</span>
+            <span class="ml-auto" *ngIf="getPageTitle(role.landingPage)">Landing Page: {{getPageTitle(role.landingPage)}}</span>
+            <span class="ml-auto font-normal italic text-base-content/30" *ngIf="!getPageTitle(role.landingPage)">No Landing Page Set</span>
           </div>
         </div>
 
@@ -80,7 +82,7 @@
             </button>
           </div>
 
-          <div *ngIf="!isAdaptationRole(role.name) && !isAdaptationTitle(role.name) && (visiblePages.length > 0 || !isDefaultRole(role.name))"
+          <div *ngIf="visiblePages.length > 0"
                class="tooltip align-middle" data-tip="Edit"
                (click)="mode = 'edit'; roleToManage = initRoleToManage(role); ModalService.openModal('manage')">
 
@@ -116,8 +118,8 @@
            [id]="'manage'"
            [templateRef]="MANAGE"
            [header]="mode?.capitalize() + ' role'"
-           [closeBtnText]="'Discard ' + (mode === 'add' ? 'role' : 'changes')"
-           [submitBtnText]="mode === 'add' ? mode?.capitalize() + ' role' : 'Save'"
+           [closeBtnText]="'Discard'"
+           [submitBtnText]="mode === 'add' ? mode?.capitalize() + ' role' : 'Keep Changes'"
            [actionInProgress]="loading.action"
            (submitBtnClicked)="f.onSubmit(null); mode === 'add' ? addRole() : editRole()"
            (onClose)="resetManage()">

--- a/frontend/src/app/_views/restricted/courses/course/settings/roles/roles.component.scss
+++ b/frontend/src/app/_views/restricted/courses/course/settings/roles/roles.component.scss
@@ -3,6 +3,6 @@
 }
 
 .dd-content {
-  @apply inline-block align-middle bg-base-100 border-2 border-base-content border-opacity-20 rounded-md px-3 py-2.5 w-full;
+  @apply align-middle bg-base-100 border-2 border-base-content border-opacity-20 rounded-md px-3 py-2.5 w-full;
 }
 

--- a/frontend/src/app/_views/restricted/courses/course/settings/roles/roles.component.ts
+++ b/frontend/src/app/_views/restricted/courses/course/settings/roles/roles.component.ts
@@ -117,7 +117,7 @@ export class RolesComponent implements OnInit {
 
   addRole(): void {
     if (this.f.valid) {
-      const newRole = new Role(null, this.roleToManage.name, this.roleToManage.landingPage, null);
+      const newRole = new Role(null, this.roleToManage.name, +this.roleToManage.landingPage, null);
       this.rolesHierarchySmart[newRole.name] = {role: newRole, parent: this.roleToManage.parent, children: []};
 
       if (!this.roleToManage.parent) { // no parent
@@ -137,7 +137,7 @@ export class RolesComponent implements OnInit {
   editRole() {
     if (this.f.valid) {
       this.roleToManage.itself.name = this.roleToManage.name;
-      this.roleToManage.itself.landingPage = this.roleToManage.landingPage;
+      this.roleToManage.itself.landingPage = +this.roleToManage.landingPage;
 
       ModalService.closeModal('manage');
       this.resetManage();
@@ -230,7 +230,7 @@ export class RolesComponent implements OnInit {
   initRoleToManage(role?: Role, parent?: Role): RoleManageData {
     const roleData: RoleManageData = {
       name: role?.name ?? null,
-      landingPage: role?.landingPage ?? null,
+      landingPage: role?.landingPage?.toString() ?? null,
       parent: parent ?? null,
       itself: role ?? null
     };
@@ -273,12 +273,16 @@ export class RolesComponent implements OnInit {
     return roleName === this.adaptationTitle;
   }
 
+  getPageTitle(pageValue): string {
+    return this.visiblePages.find(e => e.value == pageValue)?.text;
+  }
+
 }
 
 export interface RoleManageData {
   id?: number,
   name: string,
-  landingPage: number,
+  landingPage: string,
   parent: Role,
   itself: Role
 }

--- a/frontend/src/app/_views/restricted/courses/course/settings/rules/sections.component.html
+++ b/frontend/src/app/_views/restricted/courses/course/settings/rules/sections.component.html
@@ -64,27 +64,27 @@
                     </div>
 
                     <div>
-                      <div class="tooltip align-middle mx-1.5" [attr.data-tip]="section.name === 'Graveyard' || !section.isActive ? null : 'Edit'">
-                        <button class="{{section.name === 'Graveyard' || !section.isActive ? 'no-hover-effect': ''}} btn btn-sm btn-ghost btn-circle"
-                                (click)="section.name !== 'Graveyard' && section.isActive ? prepareManagement('edit section', section) : ''">
+                      <div class="tooltip align-middle mx-1.5" [attr.data-tip]="section.name === 'Graveyard' ? null : 'Edit'">
+                        <button class="{{section.name === 'Graveyard' ? 'no-hover-effect': ''}} btn btn-sm btn-ghost btn-circle"
+                                (click)="section.name !== 'Graveyard' ? prepareManagement('edit section', section) : ''">
                           <ng-icon name="jam-pencil-f" size="1.5rem"
-                                   class="{{section.name === 'Graveyard' || !section.isActive ? 'text-gray-300' : 'text-warning'}}"></ng-icon>
+                                   class="{{section.name === 'Graveyard' ? 'text-gray-300' : 'text-warning'}}"></ng-icon>
                         </button>
                       </div>
 
-                      <div class="tooltip align-middle mx-1.5" [attr.data-tip]="section.name === 'Graveyard' || !section.isActive ? null : 'Delete'">
-                        <button class="{{section.name === 'Graveyard' || !section.isActive ? 'no-hover-effect': ''}} btn btn-sm btn-ghost btn-circle"
-                                (click)="section.name !== 'Graveyard' && section.isActive ? prepareManagement('remove section', section) : ''">
+                      <div class="tooltip align-middle mx-1.5" [attr.data-tip]="section.name === 'Graveyard' ? null : 'Delete'">
+                        <button class="{{section.name === 'Graveyard' ? 'no-hover-effect': ''}} btn btn-sm btn-ghost btn-circle"
+                                (click)="section.name !== 'Graveyard' ? prepareManagement('remove section', section) : ''">
                           <ng-icon name="jam-trash-f" size="1.5rem"
-                                   class="{{section.name === 'Graveyard' || !section.isActive ? 'text-gray-300' : 'text-error'}}"></ng-icon>
+                                   class="{{section.name === 'Graveyard' ? 'text-gray-300' : 'text-error'}}"></ng-icon>
                         </button>
                       </div>
 
-                      <div class="tooltip align-middle mx-1.5" [attr.data-tip]="!section.isActive ? null : 'See more details'">
-                        <button class="{{!section.isActive ? 'no-hover-effect': ''}} btn btn-sm btn-ghost btn-circle"
-                                (click)="section.isActive ? prepareManagement('see section', section) : ''">
+                      <div class="tooltip align-middle mx-1.5" [attr.data-tip]="'See more details'">
+                        <button class="btn btn-sm btn-ghost btn-circle"
+                                (click)="prepareManagement('see section', section)">
                           <ng-icon name="feather-arrow-right-circle" size="1.5rem"
-                                   class="{{section.isActive ? 'text-primary' : 'text-gray-300'}}"></ng-icon>
+                                   class="text-primary"></ng-icon>
                         </button>
                       </div>
                     </div>

--- a/frontend/src/app/_views/restricted/courses/courses/courses.component.ts
+++ b/frontend/src/app/_views/restricted/courses/courses/courses.component.ts
@@ -336,7 +336,6 @@ export class CoursesComponent implements OnInit {
 
   async getRedirectLink(course: Course): Promise<string> {
     const link = '/courses/' + course.id;
-    if (this.user.isAdmin) return link + '/overview'; // admins go to overview page
 
     const userLandingPage = await this.api.getUserLandingPage(course.id, this.user.id).toPromise();
     const pageID = userLandingPage?.id || course.landingPage;


### PR DESCRIPTION
Tweaks based on last week's meeting:
- Roles page now shows the landing page of each role, renamed the buttons, and fixed the select to display the initial value
- Fix landing page being overwriten for professors
- Rich text editor link to file now turns selected text into link (if no selection inserts the name of the file)
- Rule sections are editable even if disabled